### PR TITLE
feat: add lab1 judge pipeline

### DIFF
--- a/backend/app/routers/labs.py
+++ b/backend/app/routers/labs.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import os
 import uuid
+from typing import Any, Dict
 
 import httpx  # type: ignore[import]
 from fastapi import APIRouter, Depends, HTTPException  # type: ignore[import]
 from pydantic import BaseModel  # type: ignore[import]
 
+from ..services.judge_service import JudgeService, get_judge_service
 from ..services.runner_client import RunnerClient, get_runner_client
 
 router = APIRouter(prefix="/labs", tags=["labs"])
@@ -18,6 +20,23 @@ class LabStartResponse(BaseModel):
     session_id: str
     ttl: int
     runner_container: str
+
+
+class LabCheckRequest(BaseModel):
+    session_id: str
+
+
+class JudgeFailureResponse(BaseModel):
+    code: str
+    message: str
+    hint: str | None = None  # type: ignore[name-defined]
+
+
+class LabCheckResponse(BaseModel):
+    passed: bool
+    failures: list[JudgeFailureResponse]
+    metrics: Dict[str, Any]
+    notes: Dict[str, Any]
 
 
 @router.post("/{lab_slug}/start", response_model=LabStartResponse)
@@ -37,3 +56,18 @@ async def start_lab(lab_slug: str, runner: RunnerClient = Depends(get_runner_cli
         raise HTTPException(status_code=502, detail="Runner response missing container reference")
 
     return LabStartResponse(session_id=session_id, ttl=SESSION_TTL_SECONDS, runner_container=container_name)
+
+
+@router.post("/{lab_slug}/check", response_model=LabCheckResponse)
+async def check_lab(
+    lab_slug: str,
+    request: LabCheckRequest,
+    runner: RunnerClient = Depends(get_runner_client),
+    judge: JudgeService = Depends(get_judge_service),
+) -> LabCheckResponse:
+    result = await judge.evaluate(lab_slug, request.session_id, runner)
+    failures = [
+        JudgeFailureResponse(code=failure.code, message=failure.message, hint=failure.hint)
+        for failure in result.failures
+    ]
+    return LabCheckResponse(passed=result.passed, failures=failures, metrics=result.metrics, notes=result.notes)

--- a/backend/app/services/judge_service.py
+++ b/backend/app/services/judge_service.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Dict
+
+from fastapi import HTTPException
+
+from judge import JudgeResult
+from judge.labs import evaluate_lab1
+from .runner_client import RunnerClient
+
+
+LabHandler = Callable[[str, RunnerClient], Awaitable[JudgeResult]]
+
+
+class JudgeService:
+    """Dispatch lab checks to the appropriate judge implementation."""
+
+    def __init__(self) -> None:
+        self._handlers: Dict[str, LabHandler] = {
+            "lab1": evaluate_lab1,
+        }
+
+    async def evaluate(self, lab_slug: str, session_id: str, runner: RunnerClient) -> JudgeResult:
+        handler = self._handlers.get(lab_slug)
+        if handler is None:
+            raise HTTPException(status_code=404, detail=f"No judge available for lab '{lab_slug}'")
+        return await handler(session_id, runner)
+
+
+def get_judge_service() -> JudgeService:
+    return JudgeService()

--- a/backend/app/services/runner_client.py
+++ b/backend/app/services/runner_client.py
@@ -87,6 +87,25 @@ class RunnerClient:
             response.raise_for_status()
             return response.json()
 
+    async def exec(
+        self,
+        session_id: str,
+        *,
+        command: list[str],
+        workdir: str | None = None,
+        environment: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        payload = {
+            "session_id": session_id,
+            "command": command,
+            "workdir": workdir,
+            "environment": environment or {},
+        }
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.post(f"{self._base_url}/exec", json=payload)
+            response.raise_for_status()
+            return response.json()
+
     async def stop_run(
         self,
         session_id: str,

--- a/backend/tests/test_judge_lab1.py
+++ b/backend/tests/test_judge_lab1.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Optional
+
+import sys
+from pathlib import Path
+
+import httpx  # type: ignore[import]
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from judge.labs.lab1 import evaluate
+
+
+class FakeRunner:
+    def __init__(
+        self,
+        *,
+        dockerignore_content: Optional[str] = None,
+        build_response: Optional[Dict[str, Any]] = None,
+        run_response: Optional[Dict[str, Any]] = None,
+        health_success: bool = True,
+    ) -> None:
+        self._dockerignore_content = dockerignore_content
+        self._build_response = build_response or {
+            "image_tag": "containrlab/test:latest",
+            "logs": ["Step 1/1"],
+            "metrics": {"elapsed_seconds": 1.23, "image_size_mb": 42.0},
+        }
+        self._run_response = run_response or {
+            "container_name": "rl_app_123",
+            "logs": ["running"],
+            "elapsed_seconds": 0.25,
+        }
+        self._health_success = health_success
+        self.stop_calls: list[Dict[str, Any]] = []
+        self.exec_invocations: list[list[str]] = []
+
+    async def exec(
+        self,
+        session_id: str,
+        *,
+        command: list[str],
+        workdir: str | None = None,
+        environment: Dict[str, str] | None = None,
+    ) -> Dict[str, Any]:
+        self.exec_invocations.append(command)
+        joined = " ".join(command)
+        if "cat /workspace/.dockerignore" in joined:
+            if self._dockerignore_content is None:
+                return {"exit_code": 1, "logs": []}
+            return {"exit_code": 0, "logs": self._dockerignore_content.splitlines()}
+        if "curl" in joined:
+            if self._health_success:
+                return {"exit_code": 0, "logs": ["200"]}
+            return {"exit_code": 7, "logs": ["000"]}
+        raise AssertionError(f"Unexpected exec command: {command}")
+
+    async def build(
+        self,
+        session_id: str,
+        *,
+        context_path: str = "/workspace",
+        dockerfile_path: str = "Dockerfile",
+        image_tag: str | None = None,
+        build_args: Dict[str, str] | None = None,
+    ) -> Dict[str, Any]:
+        return self._build_response
+
+    async def run(
+        self,
+        session_id: str,
+        *,
+        image: str,
+        command: list[str] | None = None,
+        env: Dict[str, str] | None = None,
+        ports: list[str] | None = None,
+        name: str | None = None,
+        detach: bool = True,
+        auto_remove: bool = False,
+        remove_existing: bool = True,
+    ) -> Dict[str, Any]:
+        return self._run_response
+
+    async def stop_run(
+        self,
+        session_id: str,
+        *,
+        container_name: str | None = None,
+        timeout: int = 10,
+        remove: bool = True,
+        ignore_missing: bool = True,
+    ) -> Dict[str, Any]:
+        call = {
+            "session_id": session_id,
+            "container_name": container_name,
+            "timeout": timeout,
+            "remove": remove,
+            "ignore_missing": ignore_missing,
+        }
+        self.stop_calls.append(call)
+        return {"ok": True, "stopped": True, "removed": True, "logs": []}
+
+
+def test_lab1_success() -> None:
+    runner = FakeRunner(
+        dockerignore_content="node_modules\nvenv\n",
+    )
+    result = asyncio.run(evaluate("abc123", runner))
+    assert result.passed is True
+    assert not result.failures
+    assert result.metrics["build"]["elapsed_seconds"] == runner._build_response["metrics"]["elapsed_seconds"]
+    assert runner.stop_calls  # container cleanup triggered
+
+
+def test_lab1_missing_dockerignore_entries() -> None:
+    runner = FakeRunner(
+        dockerignore_content="node_modules\n",
+    )
+    result = asyncio.run(evaluate("abc123", runner))
+    assert result.passed is False
+    assert any(failure.code == "dockerignore_missing_entries" for failure in result.failures)
+
+
+def test_lab1_build_failure() -> None:
+    response = httpx.Response(
+        status_code=500,
+        json={"error": "docker build failed", "logs": ["boom"]},
+        request=httpx.Request("POST", "http://runner/build"),
+    )
+    runner = FakeRunner(dockerignore_content="node_modules\nvenv\n")
+
+    async def failing_build(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+        raise httpx.HTTPStatusError("boom", request=response.request, response=response)
+
+    runner.build = failing_build  # type: ignore[assignment]
+    result = asyncio.run(evaluate("abc123", runner))
+    assert result.passed is False
+    assert any(failure.code == "docker_build_failed" for failure in result.failures)
+    assert result.notes.get("build_logs") == ["boom"]

--- a/judge/__init__.py
+++ b/judge/__init__.py
@@ -1,0 +1,8 @@
+"""
+Judging helper modules for ContainrLab labs.
+
+Each lab exposes an evaluate(session_id, runner) coroutine that returns a JudgeResult.
+The backend imports these helpers to orchestrate checks via the runner service.
+"""
+
+from .models import JudgeFailure, JudgeResult  # noqa: F401

--- a/judge/labs/__init__.py
+++ b/judge/labs/__init__.py
@@ -1,0 +1,1 @@
+from .lab1 import evaluate as evaluate_lab1  # noqa: F401

--- a/judge/labs/lab1.py
+++ b/judge/labs/lab1.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Protocol
+
+import httpx  # type: ignore[import]
+
+from judge.models import JudgeResult
+
+REQUIRED_DOCKERIGNORE_PATTERNS = ("node_modules", "venv")
+DEFAULT_PORT = 8080
+HEALTH_PATH = "/health"
+
+
+class RunnerProtocol(Protocol):
+    async def build(
+        self,
+        session_id: str,
+        *,
+        context_path: str = "/workspace",
+        dockerfile_path: str = "Dockerfile",
+        image_tag: str | None = None,
+        build_args: Dict[str, str] | None = None,
+    ) -> Dict[str, Any]:
+        ...
+
+    async def run(
+        self,
+        session_id: str,
+        *,
+        image: str,
+        command: list[str] | None = None,
+        env: Dict[str, str] | None = None,
+        ports: list[str] | None = None,
+        name: str | None = None,
+        detach: bool = True,
+        auto_remove: bool = False,
+        remove_existing: bool = True,
+    ) -> Dict[str, Any]:
+        ...
+
+    async def stop_run(
+        self,
+        session_id: str,
+        *,
+        container_name: str | None = None,
+        timeout: int = 10,
+        remove: bool = True,
+        ignore_missing: bool = True,
+    ) -> Dict[str, Any]:
+        ...
+
+    async def exec(
+        self,
+        session_id: str,
+        *,
+        command: list[str],
+        workdir: str | None = None,
+        environment: Dict[str, str] | None = None,
+    ) -> Dict[str, Any]:
+        ...
+
+
+async def evaluate(session_id: str, runner: RunnerProtocol) -> JudgeResult:
+    """Run Lab 1 checks inside the learner's runner session."""
+    result = JudgeResult(passed=True)
+
+    dockerignore = await _read_dockerignore(session_id, runner, result)
+    if dockerignore is not None:
+        _validate_dockerignore(dockerignore, result)
+
+    build_info = await _attempt_build(session_id, runner, result)
+    if not build_info:
+        return result
+
+    image_tag = build_info["image_tag"]
+    result.metrics["image_tag"] = image_tag
+    result.metrics["build"] = build_info.get("metrics", {})
+    result.notes["build_logs"] = build_info.get("logs", [])
+
+    run_info = await _exercise_container(session_id, runner, image_tag, result)
+    if run_info:
+        result.metrics["run"] = {"elapsed_seconds": run_info.get("elapsed_seconds")}
+
+    return result
+
+
+async def _read_dockerignore(session_id: str, runner: RunnerProtocol, result: JudgeResult) -> str | None:
+    response = await runner.exec(
+        session_id=session_id,
+        command=["sh", "-lc", "cat /workspace/.dockerignore"],
+    )
+    if response.get("exit_code", 1) != 0:
+        result.add_failure(
+            code="dockerignore_missing",
+            message="Missing .dockerignore file in workspace.",
+            hint="Create a .dockerignore file so sensitive and heavy directories stay out of the image context.",
+        )
+        return None
+    return "\n".join(response.get("logs", []))
+
+
+def _validate_dockerignore(contents: str, result: JudgeResult) -> None:
+    lines = {
+        line.strip()
+        for line in contents.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    }
+    missing = [
+        pattern
+        for pattern in REQUIRED_DOCKERIGNORE_PATTERNS
+        if not any(pattern in line for line in lines)
+    ]
+    if missing:
+        pretty = ", ".join(missing)
+        result.add_failure(
+            code="dockerignore_missing_entries",
+            message=f".dockerignore should ignore: {pretty}",
+            hint="Add the missing entries to reduce context size, for example 'node_modules' or 'venv/'.",
+        )
+
+
+async def _attempt_build(session_id: str, runner: RunnerProtocol, result: JudgeResult) -> Dict[str, Any] | None:
+    image_tag = f"containrlab/lab1-{session_id[:12]}"
+    try:
+        build_response = await runner.build(
+            session_id=session_id,
+            context_path="/workspace",
+            dockerfile_path="Dockerfile",
+            image_tag=image_tag,
+        )
+        return build_response
+    except httpx.HTTPStatusError as exc:
+        detail = _extract_runner_detail(exc)
+        hint = detail.get("hint") if isinstance(detail, dict) else None
+        logs = detail.get("logs") if isinstance(detail, dict) else None
+        if logs:
+            result.notes["build_logs"] = logs
+        result.add_failure(
+            code="docker_build_failed",
+            message="Docker build failed inside the runner.",
+            hint=hint or (detail.get("error") if isinstance(detail, dict) else str(exc)),
+        )
+        return None
+    except httpx.HTTPError as exc:
+        result.add_failure(
+            code="runner_unavailable",
+            message="Failed to contact runner while building the image.",
+            hint=str(exc),
+        )
+        return None
+
+
+async def _exercise_container(session_id: str, runner: RunnerProtocol, image_tag: str, result: JudgeResult) -> Dict[str, Any] | None:
+    container_name: str | None = None
+    try:
+        run_response = await runner.run(
+            session_id=session_id,
+            image=image_tag,
+            command=[],
+            ports=[f"{DEFAULT_PORT}:{DEFAULT_PORT}"],
+            detach=True,
+            auto_remove=False,
+            remove_existing=True,
+        )
+        container_name = run_response.get("container_name")
+        if not await _probe_health(session_id, runner):
+            result.add_failure(
+                code="healthcheck_failed",
+                message=f"Container failed to respond on http://localhost:{DEFAULT_PORT}{HEALTH_PATH}.",
+                hint="Ensure the app listens on port 8080 and exposes a /health endpoint that returns 200.",
+            )
+        return run_response
+    except httpx.HTTPStatusError as exc:
+        detail = _extract_runner_detail(exc)
+        hint = detail.get("hint") if isinstance(detail, dict) else None
+        logs = detail.get("logs") if isinstance(detail, dict) else None
+        if logs:
+            result.notes.setdefault("runtime_logs", logs)
+        result.add_failure(
+            code="docker_run_failed",
+            message="docker run failed inside the runner.",
+            hint=hint or (detail.get("error") if isinstance(detail, dict) else str(exc)),
+        )
+        return None
+    except httpx.HTTPError as exc:
+        result.add_failure(
+            code="runner_unavailable",
+            message="Failed to contact runner while running the container.",
+            hint=str(exc),
+        )
+        return None
+    finally:
+        if container_name:
+            await _safe_stop(session_id, runner, container_name)
+
+
+async def _probe_health(session_id: str, runner: RunnerProtocol) -> bool:
+    command = [
+        "sh",
+        "-lc",
+        f"curl -sS -o /dev/null -w '%{{http_code}}' http://127.0.0.1:{DEFAULT_PORT}{HEALTH_PATH}",
+    ]
+    for attempt in range(5):
+        response = await runner.exec(session_id=session_id, command=command)
+        exit_code = response.get("exit_code", 1)
+        logs = response.get("logs", [])
+        last_line = logs[-1] if logs else ""
+        if exit_code == 0 and last_line.strip() == "200":
+            return True
+        await asyncio.sleep(1 + attempt * 0.5)
+    return False
+
+
+async def _safe_stop(session_id: str, runner: RunnerProtocol, container_name: str) -> None:
+    try:
+        await runner.stop_run(
+            session_id=session_id,
+            container_name=container_name,
+            timeout=3,
+            remove=True,
+            ignore_missing=True,
+        )
+    except httpx.HTTPError:
+        # Best effort cleanup; suppress errors so judging result still returns.
+        return
+
+
+def _extract_runner_detail(exc: httpx.HTTPStatusError) -> Dict[str, Any] | str:
+    try:
+        return exc.response.json()
+    except ValueError:
+        return exc.response.text

--- a/judge/models.py
+++ b/judge/models.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass(slots=True)
+class JudgeFailure:
+    code: str
+    message: str
+    hint: Optional[str] = None
+
+
+@dataclass(slots=True)
+class JudgeResult:
+    passed: bool
+    failures: List[JudgeFailure] = field(default_factory=list)
+    metrics: Dict[str, Any] = field(default_factory=dict)
+    notes: Dict[str, Any] = field(default_factory=dict)
+
+    def add_failure(self, code: str, message: str, hint: Optional[str] = None) -> None:
+        self.failures.append(JudgeFailure(code=code, message=message, hint=hint))
+        self.passed = False

--- a/runner/supervisor/requirements.txt
+++ b/runner/supervisor/requirements.txt
@@ -2,4 +2,3 @@ docker==7.1.0
 pydantic==2.9.2
 fastapi==0.114.0
 uvicorn[standard]==0.30.1
-docker==7.1.0


### PR DESCRIPTION
fixes #4 
This pull request introduces a complete judging and feedback pipeline for lab exercises, including backend API endpoints, a modular judge service, a lab-specific evaluation implementation, and supporting runner and supervisor extensions. The changes enable automated checking of lab submissions, capturing failures, metrics, and notes, and returning detailed results to users. The implementation is modular, allowing for future extension to additional labs.

The most important changes are:

**Backend API and Judging Integration:**

* Added a `/labs/{lab_slug}/check` endpoint to the FastAPI backend, accepting a session ID and returning a structured result with pass/fail status, failure details, metrics, and notes. This endpoint uses a new `JudgeService` to dispatch lab checks. (`backend/app/routers/labs.py`, `backend/app/services/judge_service.py`) [[1]](diffhunk://#diff-a870e78cf9bb173290ba31e711741a88b4b91384342c2d089c7457c2877f3a88R25-R41) [[2]](diffhunk://#diff-a870e78cf9bb173290ba31e711741a88b4b91384342c2d089c7457c2877f3a88R59-R73) [[3]](diffhunk://#diff-85dce1d559b8aa51fc83ea0e9de7a99bd5b97cf7b7e7276149dc295d9c895f47R1-R31)

* Introduced `JudgeService` as a dispatcher for lab-specific judge functions, currently supporting Lab 1 via `evaluate_lab1`, and designed for easy extension to additional labs. (`backend/app/services/judge_service.py`, `judge/labs/__init__.py`) [[1]](diffhunk://#diff-85dce1d559b8aa51fc83ea0e9de7a99bd5b97cf7b7e7276149dc295d9c895f47R1-R31) [[2]](diffhunk://#diff-1318bd685c121c9bf9f85d420c23b8723bca390d97d54aaf4e2ad0d4e007f6e0R1)

**Runner and Supervisor Enhancements:**

* Added an `exec` method to `RunnerClient` and a corresponding `/exec` endpoint to the runner supervisor, allowing execution of arbitrary commands inside running containers. This is used by the judge to inspect files and probe service health. (`backend/app/services/runner_client.py`, `runner/supervisor/server.py`) [[1]](diffhunk://#diff-4df1c9f05e246b708a48b5ebe0e8aff23e76445264b6b2a3b9be85e77cf59752R90-R108) [[2]](diffhunk://#diff-38c48b07125f94f3401ed793bdbc1fba118a7d23d852015458a356478a806bf6R67-R73) [[3]](diffhunk://#diff-38c48b07125f94f3401ed793bdbc1fba118a7d23d852015458a356478a806bf6R235-R247)

**Lab 1 Judging Logic:**

* Implemented the Lab 1 judge (`judge/labs/lab1.py`), which checks for a proper `.dockerignore`, attempts to build the Docker image, runs the container, probes the `/health` endpoint, and collects metrics and logs. Failures are recorded with codes, messages, and hints. (`judge/labs/lab1.py`)

* Defined `JudgeResult` and `JudgeFailure` dataclasses to standardize judge outputs, including a method for recording failures and aggregating results. (`judge/models.py`, `judge/__init__.py`) [[1]](diffhunk://#diff-7617d0bcdfc60fa7b970d33c06230d55ab1a69cf2f6099317c9c6a3155282edcR1-R23) [[2]](diffhunk://#diff-b6d9f7352df0ccc55df8a546b43943e21eaa2da369501e3d67343a74ae681811R1-R8)

**Testing and Miscellaneous:**

* Added comprehensive tests for the Lab 1 judge logic using a `FakeRunner` to simulate runner interactions and various failure modes. (`backend/tests/test_judge_lab1.py`)

* Updated the runner smoke test script to support API-based judge checks and new flags for skipping steps. (`scripts/runnerd_smoke.py`)

These changes lay the foundation for automated, extensible, and robust lab evaluation in the ContainrLab platform.