### PR TITLE
feat: persist lab sessions and judge attempts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ poetry.lock
 *.log
 *.pid
 .docker-compose
+sqlite/*.db
+sqlite/*.db-*
 
 # Editor
 .idea/

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ import httpx  # type: ignore[import]
 from fastapi import FastAPI, HTTPException  # type: ignore[import]
 
 from .routers import labs, sessions
+from .services.storage import get_storage
 
 app = FastAPI(title="DockrLearn API")
 
@@ -30,3 +31,8 @@ async def runnerd_healthz() -> dict:
     except httpx.HTTPError as exc:  # pragma: no cover - trivial passthrough
         raise HTTPException(status_code=502, detail=f"runnerd health check failed: {exc}") from exc
     return response.json()
+
+
+@app.on_event("startup")
+async def _startup() -> None:
+    get_storage()

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+from dataclasses import asdict
+from datetime import datetime, timezone
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from judge.models import JudgeResult
+
+DEFAULT_SQLITE_PATH = Path(
+    os.getenv(
+        "SQLITE_PATH",
+        Path(__file__).resolve().parents[3] / "sqlite" / "app.db",
+    )
+).resolve()
+
+
+class StorageError(RuntimeError):
+    """Raised when persistence operations fail."""
+
+
+class Storage:
+    """Lightweight SQLite-backed persistence for sessions and judge attempts."""
+
+    def __init__(self, db_path: Path | None = None) -> None:
+        self._db_path = (db_path or DEFAULT_SQLITE_PATH).resolve()
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        try:
+            self._connection = sqlite3.connect(
+                self._db_path,
+                detect_types=sqlite3.PARSE_DECLTYPES,
+                check_same_thread=False,
+            )
+        except sqlite3.Error as exc:  # pragma: no cover - connection failure is fatal
+            raise StorageError(f"Unable to open database at '{self._db_path}': {exc}") from exc
+        self._connection.row_factory = sqlite3.Row
+        with self._lock:
+            self._connection.execute("PRAGMA foreign_keys = ON")
+            self._connection.execute("PRAGMA journal_mode = WAL")
+
+    @property
+    def path(self) -> Path:
+        return self._db_path
+
+    def init(self) -> None:
+        schema = """
+        CREATE TABLE IF NOT EXISTS sessions (
+            session_id TEXT PRIMARY KEY,
+            lab_slug TEXT NOT NULL,
+            runner_container TEXT NOT NULL,
+            ttl_seconds INTEGER NOT NULL,
+            created_at TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS attempts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            lab_slug TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            passed INTEGER NOT NULL,
+            failures TEXT,
+            metrics TEXT,
+            notes TEXT,
+            FOREIGN KEY(session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_attempts_session ON attempts(session_id);
+        """
+        try:
+            with self._lock:
+                self._connection.executescript(schema)
+                self._connection.commit()
+        except sqlite3.Error as exc:
+            raise StorageError(f"Failed to initialise database schema: {exc}") from exc
+
+    def record_session(
+        self,
+        *,
+        session_id: str,
+        lab_slug: str,
+        runner_container: str,
+        ttl_seconds: int,
+    ) -> None:
+        created_at = _utc_now()
+        try:
+            with self._lock:
+                self._connection.execute(
+                    """
+                    INSERT OR REPLACE INTO sessions (session_id, lab_slug, runner_container, ttl_seconds, created_at)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (session_id, lab_slug, runner_container, ttl_seconds, created_at),
+                )
+                self._connection.commit()
+        except sqlite3.Error as exc:
+            raise StorageError(f"Failed to persist session '{session_id}': {exc}") from exc
+
+    def record_attempt(
+        self,
+        *,
+        session_id: str,
+        lab_slug: str,
+        result: JudgeResult,
+    ) -> None:
+        created_at = _utc_now()
+        self._ensure_session_exists(session_id=session_id, lab_slug=lab_slug)
+        failures_payload = json.dumps([asdict(failure) for failure in result.failures]) if result.failures else None
+        metrics_payload = json.dumps(result.metrics, default=_json_default) if result.metrics else None
+        notes_payload = json.dumps(result.notes, default=_json_default) if result.notes else None
+        passed_value = 1 if result.passed else 0
+
+        try:
+            with self._lock:
+                self._connection.execute(
+                    """
+                    INSERT INTO attempts (session_id, lab_slug, created_at, passed, failures, metrics, notes)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (session_id, lab_slug, created_at, passed_value, failures_payload, metrics_payload, notes_payload),
+                )
+                self._connection.commit()
+        except sqlite3.Error as exc:
+            raise StorageError(f"Failed to persist attempt for session '{session_id}': {exc}") from exc
+
+    def get_session(self, session_id: str) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            cursor = self._connection.execute(
+                "SELECT session_id, lab_slug, runner_container, ttl_seconds, created_at FROM sessions WHERE session_id = ?",
+                (session_id,),
+            )
+            row = cursor.fetchone()
+        if row is None:
+            return None
+        return dict(row)
+
+    def list_attempts(self, session_id: str) -> List[Dict[str, Any]]:
+        with self._lock:
+            cursor = self._connection.execute(
+                """
+                SELECT id, session_id, lab_slug, created_at, passed, failures, metrics, notes
+                FROM attempts
+                WHERE session_id = ?
+                ORDER BY id ASC
+                """,
+                (session_id,),
+            )
+            rows = cursor.fetchall()
+        attempts: List[Dict[str, Any]] = []
+        for row in rows:
+            attempts.append(
+                {
+                    "id": row["id"],
+                    "session_id": row["session_id"],
+                    "lab_slug": row["lab_slug"],
+                    "created_at": row["created_at"],
+                    "passed": bool(row["passed"]),
+                    "failures": json.loads(row["failures"]) if row["failures"] else [],
+                    "metrics": json.loads(row["metrics"]) if row["metrics"] else {},
+                    "notes": json.loads(row["notes"]) if row["notes"] else {},
+                }
+            )
+        return attempts
+
+    def _ensure_session_exists(self, *, session_id: str, lab_slug: str) -> None:
+        try:
+            with self._lock:
+                self._connection.execute(
+                    """
+                    INSERT OR IGNORE INTO sessions (session_id, lab_slug, runner_container, ttl_seconds, created_at)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (session_id, lab_slug, "unknown", 0, _utc_now()),
+                )
+                self._connection.commit()
+        except sqlite3.Error as exc:
+            raise StorageError(f"Failed to ensure session '{session_id}' exists: {exc}") from exc
+
+
+@lru_cache
+def get_storage() -> Storage:
+    storage = Storage()
+    storage.init()
+    return storage
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _json_default(value: Any) -> Any:
+    if isinstance(value, Path):
+        return str(value)
+    raise TypeError(f"Object of type {type(value)!r} is not JSON serializable")

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from judge.models import JudgeFailure, JudgeResult
+
+from backend.app.services.storage import Storage
+
+
+def test_storage_records_session_and_attempt(tmp_path: Path) -> None:
+    db_path = tmp_path / "app.db"
+    storage = Storage(db_path=db_path)
+    storage.init()
+
+    session_id = "abc123"
+    storage.record_session(
+        session_id=session_id,
+        lab_slug="lab1",
+        runner_container="rl_sess_abc123",
+        ttl_seconds=2700,
+    )
+
+    session = storage.get_session(session_id)
+    assert session is not None
+    assert session["lab_slug"] == "lab1"
+    assert session["runner_container"] == "rl_sess_abc123"
+
+    result = JudgeResult(
+        passed=False,
+        failures=[JudgeFailure(code="fail", message="missing file")],
+        metrics={"image_size_mb": 42.1},
+        notes={"hints": ["add a Dockerfile"]},
+    )
+    storage.record_attempt(session_id=session_id, lab_slug="lab1", result=result)
+
+    attempts = storage.list_attempts(session_id)
+    assert len(attempts) == 1
+    saved = attempts[0]
+    assert saved["passed"] is False
+    assert saved["metrics"]["image_size_mb"] == 42.1
+    assert saved["failures"][0]["code"] == "fail"
+
+
+def test_storage_get_session_missing(tmp_path: Path) -> None:
+    storage = Storage(db_path=tmp_path / "other.db")
+    storage.init()
+    assert storage.get_session("missing") is None
+
+
+def test_record_attempt_backfills_session(tmp_path: Path) -> None:
+    storage = Storage(db_path=tmp_path / "backfill.db")
+    storage.init()
+
+    session_id = "ghost"
+    result = JudgeResult(passed=True, failures=[], metrics={}, notes={})
+    storage.record_attempt(session_id=session_id, lab_slug="lab-z", result=result)
+
+    session = storage.get_session(session_id)
+    assert session is not None
+    assert session["runner_container"] == "unknown"
+    assert session["ttl_seconds"] == 0


### PR DESCRIPTION
fixes #10 
This pull request introduces a new SQLite-backed persistence layer for tracking lab sessions and judge attempts, and integrates it into the labs API. The main changes include the implementation of the `Storage` class, dependency injection of storage into relevant endpoints, and associated error handling. Additionally, tests are provided to verify the new storage functionality.

**Persistence Layer Implementation:**

* Added a new `Storage` class in `backend/app/services/storage.py` that manages session and attempt data using SQLite. This includes methods for recording sessions and judge attempts, retrieving session data, and listing attempts. The storage is initialized on app startup, and thread safety is ensured with locks. (`[backend/app/services/storage.pyR1-R197](diffhunk://#diff-45f32c11fc1beff332c751541f06e2559d48393d657016c4ce1741ed3bea3448R1-R197)`)
* Introduced a custom `StorageError` exception for error handling in persistence operations. (`[backend/app/services/storage.pyR1-R197](diffhunk://#diff-45f32c11fc1beff332c751541f06e2559d48393d657016c4ce1741ed3bea3448R1-R197)`)
* Provided a `get_storage` function using `lru_cache` for dependency injection and singleton behavior, ensuring the database is initialized once. (`[backend/app/services/storage.pyR1-R197](diffhunk://#diff-45f32c11fc1beff332c751541f06e2559d48393d657016c4ce1741ed3bea3448R1-R197)`)

**API Integration:**

* Injected the `Storage` dependency into the `/labs/{lab_slug}/start` and `/labs/{lab_slug}/check` endpoints using FastAPI's `Depends`, and updated these endpoints to record sessions and judge attempts in the database. Errors in storage operations now return HTTP 500 responses. (`[[1]](diffhunk://#diff-a870e78cf9bb173290ba31e711741a88b4b91384342c2d089c7457c2877f3a88R14)`, `[[2]](diffhunk://#diff-a870e78cf9bb173290ba31e711741a88b4b91384342c2d089c7457c2877f3a88L55-R60)`, `[[3]](diffhunk://#diff-a870e78cf9bb173290ba31e711741a88b4b91384342c2d089c7457c2877f3a88R75-R84)`, `[[4]](diffhunk://#diff-a870e78cf9bb173290ba31e711741a88b4b91384342c2d089c7457c2877f3a88R121-R131)`)
* Ensured the storage layer is initialized at FastAPI application startup by calling `get_storage()` in a startup event handler. (`[[1]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3R7)`, `[[2]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3R34-R38)`)

**Testing:**

* Added tests for the `Storage` class in `backend/tests/test_storage.py`, covering session/attempt recording, retrieval, and session backfilling. (`[backend/tests/test_storage.pyR1-R61](diffhunk://#diff-7a3924d6af8b340109d5f78eaa8003843f0912d3c62c182cbf92875cffbb7d2dR1-R61)`)