### PR TITLE
feat: expose session history and ensure judge persistence

### DIFF
--- a/backend/app/routers/labs.py
+++ b/backend/app/routers/labs.py
@@ -128,5 +128,6 @@ async def check_lab(
     try:
         storage.record_attempt(session_id=request.session_id, lab_slug=lab_slug, result=result)
     except StorageError as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        status = 404 if "not found" in str(exc).lower() else 500
+        raise HTTPException(status_code=status, detail=str(exc)) from exc
     return LabCheckResponse(passed=result.passed, failures=failures, metrics=result.metrics, notes=result.notes)

--- a/backend/tests/test_sessions_router.py
+++ b/backend/tests/test_sessions_router.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient  # type: ignore[import]
+
+from backend.app.main import app
+from backend.app.services.storage import Storage, get_storage
+from judge.models import JudgeResult
+
+
+def _prepare_storage(tmp_path: Path) -> Storage:
+    storage = Storage(db_path=tmp_path / "api.db")
+    storage.init()
+    return storage
+
+
+def test_get_session_detail_returns_attempts(tmp_path: Path) -> None:
+    storage = _prepare_storage(tmp_path)
+    app.dependency_overrides[get_storage] = lambda: storage
+
+    session_id = "abc123"
+    storage.record_session(
+        session_id=session_id,
+        lab_slug="lab1",
+        runner_container="container",
+        ttl_seconds=2700,
+    )
+
+    for idx in range(2):
+        storage.record_attempt(
+            session_id=session_id,
+            lab_slug="lab1",
+            result=JudgeResult(passed=bool(idx), failures=[], metrics={"idx": idx}, notes={}),
+        )
+
+    client = TestClient(app)
+    response = client.get(f"/sessions/{session_id}?limit=1")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["session_id"] == session_id
+    assert payload["lab_slug"] == "lab1"
+    assert len(payload["attempts"]) == 1
+    assert payload["attempts"][0]["metrics"]["idx"] == 1
+
+    app.dependency_overrides.clear()
+
+
+def test_get_session_detail_missing(tmp_path: Path) -> None:
+    storage = _prepare_storage(tmp_path)
+    app.dependency_overrides[get_storage] = lambda: storage
+
+    client = TestClient(app)
+    response = client.get("/sessions/missing")
+    assert response.status_code == 404
+
+    app.dependency_overrides.clear()

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest  # type: ignore[import]
+
 from judge.models import JudgeFailure, JudgeResult
 
 from backend.app.services.storage import Storage
@@ -41,21 +43,42 @@ def test_storage_records_session_and_attempt(tmp_path: Path) -> None:
     assert saved["failures"][0]["code"] == "fail"
 
 
+def test_list_attempts_limit_returns_latest_first(tmp_path: Path) -> None:
+    storage = Storage(db_path=tmp_path / "limit.db")
+    storage.init()
+    storage.record_session(
+        session_id="abc",
+        lab_slug="lab1",
+        runner_container="container",
+        ttl_seconds=123,
+    )
+
+    for idx in range(3):
+        storage.record_attempt(
+            session_id="abc",
+            lab_slug="lab1",
+            result=JudgeResult(passed=bool(idx % 2), failures=[], metrics={"idx": idx}, notes={}),
+        )
+
+    attempts = storage.list_attempts("abc", limit=2)
+    assert len(attempts) == 2
+    assert attempts[0]["metrics"]["idx"] == 2
+    assert attempts[1]["metrics"]["idx"] == 1
+
+
 def test_storage_get_session_missing(tmp_path: Path) -> None:
     storage = Storage(db_path=tmp_path / "other.db")
     storage.init()
     assert storage.get_session("missing") is None
 
 
-def test_record_attempt_backfills_session(tmp_path: Path) -> None:
+def test_record_attempt_requires_existing_session(tmp_path: Path) -> None:
     storage = Storage(db_path=tmp_path / "backfill.db")
     storage.init()
 
     session_id = "ghost"
     result = JudgeResult(passed=True, failures=[], metrics={}, notes={})
-    storage.record_attempt(session_id=session_id, lab_slug="lab-z", result=result)
 
-    session = storage.get_session(session_id)
-    assert session is not None
-    assert session["runner_container"] == "unknown"
-    assert session["ttl_seconds"] == 0
+    with pytest.raises(Exception) as excinfo:
+        storage.record_attempt(session_id=session_id, lab_slug="lab-z", result=result)
+    assert "not found" in str(excinfo.value)


### PR DESCRIPTION
fixes #7 
This pull request introduces a new API endpoint to retrieve session details, including recent lab attempts, and refines session/attempt storage logic. It also adds tests for the new endpoint and improves error handling for session-related operations. The most important changes are grouped below:

**Session Detail Endpoint & API Enhancements:**

* Added a new `GET /sessions/{session_id}` endpoint that returns session details and a list of recent attempts, with optional limiting and proper error handling if the session is missing (`SessionDetailResponse`, `AttemptEntry` in `sessions.py`). [[1]](diffhunk://#diff-b1aea68deeaa71d65cc595829d06dc0bab4a30b0a97eb551edfc43652166fdd6R59-R77) [[2]](diffhunk://#diff-b1aea68deeaa71d65cc595829d06dc0bab4a30b0a97eb551edfc43652166fdd6R152-R188)
* Updated smoke test script (`runnerd_smoke.py`) to call the new session detail endpoint after running a judge operation, printing its output for verification. [[1]](diffhunk://#diff-df8ba53ca2e5ff17ad02ca090158e3cb1e5d6a9531f8c872a6946e0887823c7eR28-R52) [[2]](diffhunk://#diff-df8ba53ca2e5ff17ad02ca090158e3cb1e5d6a9531f8c872a6946e0887823c7eL68-R84) [[3]](diffhunk://#diff-df8ba53ca2e5ff17ad02ca090158e3cb1e5d6a9531f8c872a6946e0887823c7eL87) [[4]](diffhunk://#diff-df8ba53ca2e5ff17ad02ca090158e3cb1e5d6a9531f8c872a6946e0887823c7eR113-R123) [[5]](diffhunk://#diff-df8ba53ca2e5ff17ad02ca090158e3cb1e5d6a9531f8c872a6946e0887823c7eR150-R160)

**Storage Layer Improvements:**

* Changed `record_attempt` to require that a session exists before recording an attempt, raising a `StorageError` if not found, and removed the backfilling logic that auto-created sessions. [[1]](diffhunk://#diff-45f32c11fc1beff332c751541f06e2559d48393d657016c4ce1741ed3bea3448L110-R113) [[2]](diffhunk://#diff-45f32c11fc1beff332c751541f06e2559d48393d657016c4ce1741ed3bea3448L168-L181)
* Enhanced `list_attempts` to support a `limit` parameter and to return attempts in descending order (latest first).

**Error Handling:**

* Improved error handling in the lab check endpoint to return a 404 error if the session is not found, rather than always returning a 500.

**Testing:**

* Added new tests for the session detail endpoint and the storage layer’s attempt limiting and ordering, as well as for the stricter session existence requirement. [[1]](diffhunk://#diff-a69f19c5fe726e728bd9174caaee337d6ef917b008e285d41faffad670a88d9bR1-R57) [[2]](diffhunk://#diff-7a3924d6af8b340109d5f78eaa8003843f0912d3c62c182cbf92875cffbb7d2dR5-R6) [[3]](diffhunk://#diff-7a3924d6af8b340109d5f78eaa8003843f0912d3c62c182cbf92875cffbb7d2dR46-R84)

These changes together improve the API’s usability and reliability for session and attempt management.