### PR TITLE
chore: remove deprecated compose version key

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   web:
     build:


### PR DESCRIPTION
fixes #16 
This pull request makes a small change to the `compose/docker-compose.yml` file by removing the version declaration at the top of the file. This change simplifies the configuration and relies on the default version behavior in recent versions of Docker Compose.