### PR TITLE
feat: render lab readme as markdown

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,9 +10,13 @@
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.19",
+    "highlight.js": "^11.11.1",
     "next": "14.2.7",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "react-markdown": "^10.1.0",
+    "rehype-highlight": "^7.0.2",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/frontend/src/app/labs/[slug]/page.tsx
+++ b/frontend/src/app/labs/[slug]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import LabActions from "@/components/LabActions";
+import Markdown from "@/components/Markdown";
 import { fetchLab, fetchSession, LabDetail, SessionDetail } from "@/lib/labs";
 
 type LabPageProps = {
@@ -79,9 +80,7 @@ export default async function LabPage({ params, searchParams }: LabPageProps) {
       <section className="space-y-3 rounded-xl border border-slate-800 bg-slate-900/60 p-6">
         <h2 className="text-lg font-semibold text-slate-100">README</h2>
         <Suspense fallback={<p className="text-sm text-slate-500">Loading...</p>}>
-          <article className="prose prose-invert max-w-none whitespace-pre-wrap text-slate-200">
-            {lab.readme}
-          </article>
+          <Markdown content={lab.readme} />
         </Suspense>
       </section>
     </div>

--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
+import "highlight.js/styles/atom-one-dark.css";
+
+type MarkdownProps = {
+  content: string;
+};
+
+export default function Markdown({ content }: MarkdownProps) {
+  return (
+    <div className="prose prose-invert max-w-none">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeHighlight]}
+        components={{
+          table: ({ node, ...props }) => (
+            <div className="overflow-x-auto">
+              {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+              <table {...props} />
+            </div>
+          ),
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}


### PR DESCRIPTION
fixes #20 
This pull request introduces a new `Markdown` component to improve the rendering of markdown content, especially for lab READMEs, by supporting GitHub-flavored markdown and syntax highlighting. It also adds the necessary dependencies for these enhancements.

Markdown rendering improvements:

* Added a new `Markdown` component (`frontend/src/components/Markdown.tsx`) that uses `react-markdown`, `remark-gfm` for GitHub-flavored markdown, and `rehype-highlight` for syntax highlighting, along with styling for code blocks.
* Updated the lab detail page (`frontend/src/app/labs/[slug]/page.tsx`) to use the new `Markdown` component for rendering the README, replacing the previous plain text rendering. ([frontend/src/app/labs/[slug]/page.tsxR5](diffhunk://#diff-6530a63ce6f905c299fbe1bb014aa5483026173ff08462e7210616b598c255daR5), [frontend/src/app/labs/[slug]/page.tsxL82-R83](diffhunk://#diff-6530a63ce6f905c299fbe1bb014aa5483026173ff08462e7210616b598c255daL82-R83))

Dependency updates:

* Added `react-markdown`, `remark-gfm`, `rehype-highlight`, and `highlight.js` to `package.json` to support advanced markdown rendering and syntax highlighting.