### PR TITLE
feat: add runner terminal websocket proxy

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,7 +3,7 @@ import os
 import httpx  # type: ignore[import]
 from fastapi import FastAPI, HTTPException  # type: ignore[import]
 
-from .routers import labs, sessions
+from .routers import labs, sessions, terminal
 from .services.storage import get_storage
 
 app = FastAPI(title="DockrLearn API")
@@ -12,6 +12,7 @@ RUNNERD_BASE_URL = os.getenv("RUNNERD_BASE_URL", "http://runnerd:8080")
 
 app.include_router(labs.router)
 app.include_router(sessions.router)
+app.include_router(terminal.router)
 
 
 @app.get("/healthz")

--- a/backend/app/routers/terminal.py
+++ b/backend/app/routers/terminal.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from urllib.parse import urlencode, urlparse, urlunparse
+
+import httpx  # type: ignore[import]
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from ..services.runner_client import RUNNERD_BASE_URL
+
+router = APIRouter()
+
+
+def _build_runner_ws_url(session_id: str, shell: str, base_url: str | None = None) -> str:
+    base = (base_url or RUNNERD_BASE_URL).rstrip("/")
+    normalized = base if "://" in base else f"http://{base}"
+    parsed = urlparse(normalized)
+    scheme = "ws"
+    if parsed.scheme == "https":
+        scheme = "wss"
+    netloc = parsed.netloc or parsed.path
+    path_base = parsed.path.rstrip("/")
+    path = (path_base + f"/terminal/{session_id}") if path_base else f"/terminal/{session_id}"
+    query = urlencode({"shell": shell})
+    return urlunparse((scheme, netloc, path, "", query, ""))
+
+
+@router.websocket("/ws/terminal/{session_id}")
+async def terminal_proxy(websocket: WebSocket, session_id: str, shell: str = "/bin/sh") -> None:
+    await websocket.accept()
+    runner_url = _build_runner_ws_url(session_id, shell)
+
+    async with httpx.AsyncClient(timeout=None) as client:
+        try:
+            async with client.ws_connect(runner_url) as runner_ws:
+                async def backend_to_runner() -> None:
+                    try:
+                        while True:
+                            message = await websocket.receive_text()
+                            await runner_ws.send_text(message)
+                    except WebSocketDisconnect:
+                        await runner_ws.aclose()
+                    except Exception:
+                        await runner_ws.aclose()
+
+                async def runner_to_backend() -> None:
+                    async for message in runner_ws.iter_text():
+                        await websocket.send_text(message)
+
+                await asyncio.gather(backend_to_runner(), runner_to_backend())
+        except (httpx.WebSocketReadError, httpx.ConnectError) as exc:
+            await websocket.close(code=1011, reason=f"Runner terminal unavailable: {exc}")
+        except WebSocketDisconnect:
+            pass
+        finally:
+            with contextlib.suppress(Exception):
+                await websocket.close()

--- a/backend/tests/test_terminal_router.py
+++ b/backend/tests/test_terminal_router.py
@@ -1,0 +1,16 @@
+from backend.app.routers.terminal import _build_runner_ws_url
+
+
+def test_build_runner_ws_url_http():
+    url = _build_runner_ws_url("abc123", "/bin/bash", base_url="http://runnerd:8080")
+    assert url == "ws://runnerd:8080/terminal/abc123?shell=%2Fbin%2Fbash"
+
+
+def test_build_runner_ws_url_https_path():
+    url = _build_runner_ws_url("xyz", "/bin/sh", base_url="https://example.com/api")
+    assert url == "wss://example.com/api/terminal/xyz?shell=%2Fbin%2Fsh"
+
+
+def test_build_runner_ws_url_bare_host():
+    url = _build_runner_ws_url("foo", "/bin/sh", base_url="runnerd:8080")
+    assert url == "ws://runnerd:8080/terminal/foo?shell=%2Fbin%2Fsh"


### PR DESCRIPTION
fixes #22 
This pull request introduces a new real-time terminal proxy feature, enabling users to interact with shell sessions inside containers via WebSockets. It adds both backend API support (in `backend/app/routers/terminal.py`) and corresponding WebSocket handling in the runner service (`runner/supervisor/server.py`). The implementation is accompanied by tests and necessary updates to the main application to register the new routes.

**Terminal WebSocket Proxy Feature:**

* Added a new `terminal` router to the backend, exposing a `/ws/terminal/{session_id}` WebSocket endpoint that proxies messages between clients and the runner service, allowing real-time shell access inside containers. (`backend/app/routers/terminal.py`, `backend/app/main.py`) [[1]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3L6-R6) [[2]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3R15) [[3]](diffhunk://#diff-b7403640e7cd358e08cd3f3f579c977815f31ac57ccc722ff5efefe2eadcdcb9R1-R58)

* Implemented a corresponding WebSocket endpoint `/terminal/{session_id}` in the runner service, which executes a shell inside the target container and relays input/output between the container and the client. It also supports terminal resizing and robust error handling. (`runner/supervisor/server.py`) [[1]](diffhunk://#diff-38c48b07125f94f3401ed793bdbc1fba118a7d23d852015458a356478a806bf6R3-R5) [[2]](diffhunk://#diff-38c48b07125f94f3401ed793bdbc1fba118a7d23d852015458a356478a806bf6L12-R14) [[3]](diffhunk://#diff-38c48b07125f94f3401ed793bdbc1fba118a7d23d852015458a356478a806bf6R29) [[4]](diffhunk://#diff-38c48b07125f94f3401ed793bdbc1fba118a7d23d852015458a356478a806bf6R251-R337)

**Testing and Utilities:**

* Added tests for the URL construction logic that builds the WebSocket address for connecting to the runner service, ensuring correct handling of various base URL formats. (`backend/tests/test_terminal_router.py`)