### PR TITLE
feat: add runner filesystem endpoints

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,7 +3,7 @@ import os
 import httpx  # type: ignore[import]
 from fastapi import FastAPI, HTTPException  # type: ignore[import]
 
-from .routers import labs, sessions, terminal
+from .routers import files, labs, sessions, terminal
 from .services.storage import get_storage
 
 app = FastAPI(title="DockrLearn API")
@@ -12,6 +12,7 @@ RUNNERD_BASE_URL = os.getenv("RUNNERD_BASE_URL", "http://runnerd:8080")
 
 app.include_router(labs.router)
 app.include_router(sessions.router)
+app.include_router(files.router)
 app.include_router(terminal.router)
 
 

--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import base64
+import binascii
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, Depends, HTTPException  # type: ignore[import]
+from pydantic import BaseModel, Field  # type: ignore[import]
+
+from ..services.runner_client import RunnerClient, get_runner_client
+
+router = APIRouter(prefix="/fs", tags=["filesystem"])
+
+
+class ListResponseEntry(BaseModel):
+    name: str
+    path: str
+    is_dir: bool
+    size: int | None = None
+    modified: float | None = None
+
+
+class ListResponse(BaseModel):
+    path: str
+    entries: List[ListResponseEntry]
+
+
+class ReadResponse(BaseModel):
+    path: str
+    encoding: str = "base64"
+    content: str
+
+
+class WriteRequest(BaseModel):
+    session_id: str
+    path: str
+    content: str
+    encoding: str = "base64"
+
+
+class WriteResponse(BaseModel):
+    ok: bool
+    path: str
+
+
+@router.get("/{session_id}/list", response_model=ListResponse)
+async def list_path(
+    session_id: str,
+    path: str | None = None,
+    runner: RunnerClient = Depends(get_runner_client),
+) -> ListResponse:
+    payload = await runner.list_path(session_id=session_id, path=path)
+    entries = [
+        ListResponseEntry(
+            name=item["name"],
+            path=item["path"],
+            is_dir=item["is_dir"],
+            size=item.get("size"),
+            modified=item.get("modified"),
+        )
+        for item in payload.get("entries", [])
+    ]
+    return ListResponse(path=path or "/workspace", entries=entries)
+
+
+@router.get("/{session_id}/read", response_model=ReadResponse)
+async def read_file(
+    session_id: str,
+    path: str,
+    runner: RunnerClient = Depends(get_runner_client),
+) -> ReadResponse:
+    payload = await runner.read_file(session_id=session_id, path=path)
+    return ReadResponse(**payload)
+
+
+@router.post("/write", response_model=WriteResponse)
+async def write_file(
+    request: WriteRequest,
+    runner: RunnerClient = Depends(get_runner_client),
+) -> WriteResponse:
+    if request.encoding != "base64":
+        raise HTTPException(status_code=400, detail="Only base64 encoding is supported")
+    try:
+        base64.b64decode(request.content)
+    except (ValueError, binascii.Error) as exc:  # type: ignore[name-defined]
+        raise HTTPException(status_code=400, detail="Invalid base64 payload") from exc
+    payload = await runner.write_file(
+        session_id=request.session_id,
+        path=request.path,
+        content_b64=request.content,
+    )
+    return WriteResponse(**payload)

--- a/backend/app/services/runner_client.py
+++ b/backend/app/services/runner_client.py
@@ -127,6 +127,38 @@ class RunnerClient:
             response.raise_for_status()
             return response.json()
 
+    async def list_path(self, session_id: str, path: str | None = None) -> dict[str, Any]:
+        payload = {"session_id": session_id, "path": path}
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(f"{self._base_url}/fs/list", json=payload)
+            response.raise_for_status()
+            return response.json()
+
+    async def read_file(self, session_id: str, path: str) -> dict[str, Any]:
+        payload = {"session_id": session_id, "path": path}
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(f"{self._base_url}/fs/read", json=payload)
+            response.raise_for_status()
+            return response.json()
+
+    async def write_file(
+        self,
+        session_id: str,
+        *,
+        path: str,
+        content_b64: str,
+    ) -> dict[str, Any]:
+        payload = {
+            "session_id": session_id,
+            "path": path,
+            "content": content_b64,
+            "encoding": "base64",
+        }
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(f"{self._base_url}/fs/write", json=payload)
+            response.raise_for_status()
+            return response.json()
+
 
 def get_runner_client() -> RunnerClient:
     """Convenience dependency for FastAPI injection."""

--- a/backend/tests/test_files_router.py
+++ b/backend/tests/test_files_router.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import base64
+from typing import Any, Dict
+
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient  # type: ignore[import]
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from backend.app.main import app
+from backend.app.services.runner_client import RunnerClient, get_runner_client
+
+
+class FakeRunner(RunnerClient):
+    def __init__(self) -> None:  # pragma: no cover - override base init
+        pass
+
+    async def list_path(self, session_id: str, path: str | None = None) -> dict[str, Any]:
+        return {
+            "entries": [
+                {"name": "Dockerfile", "path": "/workspace/Dockerfile", "is_dir": False, "size": 42, "modified": 1.0}
+            ],
+        }
+
+    async def read_file(self, session_id: str, path: str) -> dict[str, Any]:
+        return {
+            "path": path,
+            "encoding": "base64",
+            "content": base64.b64encode(b"hello").decode("ascii"),
+        }
+
+    async def write_file(self, session_id: str, *, path: str, content_b64: str) -> dict[str, Any]:
+        return {"ok": True, "path": path}
+
+
+client = TestClient(app)
+
+
+def override_runner_client() -> FakeRunner:
+    return FakeRunner()
+
+
+def test_list_path_override():
+    app.dependency_overrides[get_runner_client] = override_runner_client
+    response = client.get("/fs/test-session/list")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["entries"][0]["name"] == "Dockerfile"
+    app.dependency_overrides.clear()
+
+
+def test_write_invalid_encoding():
+    app.dependency_overrides[get_runner_client] = override_runner_client
+    response = client.post(
+        "/fs/write",
+        json={"session_id": "abc", "path": "/workspace/test.txt", "content": "abc", "encoding": "utf-8"},
+    )
+    assert response.status_code == 400
+    app.dependency_overrides.clear()

--- a/scripts/runnerd_smoke.py
+++ b/scripts/runnerd_smoke.py
@@ -100,6 +100,17 @@ def main() -> int:
         print("Run stop response:")
         print(json.dumps(stop_body, indent=2))
 
+    if api_base:
+        try:
+            print("Listing workspace via API...")
+            listing_body = _get(
+                f"{api_base or DEFAULT_API_BASE}/fs/{session_id}/list?path=/workspace",
+                timeout=30,
+            )
+            print(json.dumps(listing_body, indent=2))
+        except SystemExit as exc:
+            print(exc)
+
     if api_base and not args.skip_judge:
         print("Invoking backend judge endpoint...")
         judge_body = _post(


### PR DESCRIPTION
fixes #24 
This pull request adds a new API for file system access to the backend, enabling clients to list directories, read files, and write files within a session's workspace. It introduces a new FastAPI router (`files.py`) and corresponding endpoints in both the backend and runner service, along with input validation, error handling, and test coverage for these new features.

**New Filesystem API Implementation:**

* Added a new FastAPI router (`files.py`) with endpoints for listing directory contents, reading files, and writing files, all using base64 encoding for file contents. These endpoints validate input and handle errors appropriately.
* Registered the new `files` router in the main FastAPI application to expose the `/fs` endpoints. [[1]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3L6-R6) [[2]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3R15)

**Runner Service Support:**

* Implemented `/fs/list`, `/fs/read`, and `/fs/write` endpoints in the runner service (`server.py`) to support directory listing, file reading, and file writing inside the container. Includes secure path handling and error responses for invalid or unsafe requests. [[1]](diffhunk://#diff-38c48b07125f94f3401ed793bdbc1fba118a7d23d852015458a356478a806bf6R33-R50) [[2]](diffhunk://#diff-38c48b07125f94f3401ed793bdbc1fba118a7d23d852015458a356478a806bf6R98-R114) [[3]](diffhunk://#diff-38c48b07125f94f3401ed793bdbc1fba118a7d23d852015458a356478a806bf6R376-R458) [[4]](diffhunk://#diff-38c48b07125f94f3401ed793bdbc1fba118a7d23d852015458a356478a806bf6R620-R632)
* Added helper function `_sanitize_workspace_path` to ensure file operations do not escape the workspace directory.

**Backend Service Integration:**

* Extended the `RunnerClient` class with async methods to call the new runner endpoints for listing, reading, and writing files, enabling the backend to proxy file operations to the runner.

**Testing and Validation:**

* Added unit tests for the new file system endpoints, including tests for directory listing and input validation on file writes. Uses a fake runner client for isolation.

**Developer Tooling:**

* Updated the `runnerd_smoke.py` script to include a test for the new workspace listing API, aiding in manual and automated smoke testing.