### PR TITLE
feat: add build inspector API and panel

### DIFF
--- a/backend/tests/test_sessions_router.py
+++ b/backend/tests/test_sessions_router.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient  # type: ignore[import]
 
 from backend.app.main import app
 from backend.app.services.storage import Storage, get_storage
-from judge.models import JudgeResult
+from judge.models import JudgeFailure, JudgeResult
 
 
 def _prepare_storage(tmp_path: Path) -> Storage:
@@ -53,5 +53,38 @@ def test_get_session_detail_missing(tmp_path: Path) -> None:
     client = TestClient(app)
     response = client.get("/sessions/missing")
     assert response.status_code == 404
+
+    app.dependency_overrides.clear()
+
+
+def test_inspector_endpoint(tmp_path: Path) -> None:
+    storage = _prepare_storage(tmp_path)
+    app.dependency_overrides[get_storage] = lambda: storage
+
+    session_id = "inspect-1"
+    storage.record_session(
+        session_id=session_id,
+        lab_slug="lab1",
+        runner_container="container",
+        ttl_seconds=2700,
+    )
+    storage.record_attempt(
+        session_id=session_id,
+        lab_slug="lab1",
+        result=JudgeResult(
+            passed=False,
+            failures=[JudgeFailure(code="fail", message="oops")],
+            metrics={"image_size_mb": 42.1},
+            notes={},
+        ),
+    )
+
+    client = TestClient(app)
+    response = client.get(f"/sessions/{session_id}/inspector")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["attempt_count"] == 1
+    assert payload["metrics"]["image_size_mb"] == 42.1
+    assert payload["last_passed"] is False
 
     app.dependency_overrides.clear()

--- a/frontend/src/app/labs/[slug]/page.tsx
+++ b/frontend/src/app/labs/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Suspense } from "react";
 import WorkspacePane from "@/components/WorkspacePane";
+import InspectorPanel from "@/components/InspectorPanel";
 import { notFound } from "next/navigation";
 import LabActions from "@/components/LabActions";
 import Terminal from "@/components/Terminal";
@@ -79,6 +80,9 @@ export default async function LabPage({ params, searchParams }: LabPageProps) {
 
       <LabActions slug={params.slug} initialSession={session} />
       <WorkspacePane sessionId={session?.session_id} />
+      <div className="rounded-xl border border-slate-800 bg-slate-900/70 p-6">
+        <InspectorPanel sessionId={session?.session_id} />
+      </div>
       <div className="rounded-xl border border-slate-800 bg-slate-900/70 p-6">
         <h2 className="mb-3 text-lg font-semibold text-slate-100">Terminal</h2>
         <p className="text-sm text-slate-400">

--- a/frontend/src/components/InspectorPanel.tsx
+++ b/frontend/src/components/InspectorPanel.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { fetchInspector, type InspectorSummary } from "@/lib/labs";
+
+export default function InspectorPanel({ sessionId }: { sessionId?: string }) {
+  const [summary, setSummary] = useState<InspectorSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const load = async (id: string) => {
+    setLoading(true);
+    try {
+      const data = await fetchInspector(id);
+      setSummary(data);
+      setError(null);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Inspector unavailable";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!sessionId) {
+      setSummary(null);
+      setError(null);
+      return;
+    }
+    load(sessionId);
+  }, [sessionId]);
+
+  if (!sessionId) {
+    return <p className="text-sm text-slate-500">Start a session to view build metrics.</p>;
+  }
+
+  if (loading && !summary) {
+    return <p className="text-sm text-slate-400">Loading build metrics...</p>;
+  }
+
+  if (error) {
+    return <p className="text-sm text-red-300">{error}</p>;
+  }
+
+  if (!summary) {
+    return <p className="text-sm text-slate-500">No attempts yet.</p>;
+  }
+
+  const lastPassedText =
+    summary.last_passed === null || summary.last_passed === undefined
+      ? "n/a"
+      : summary.last_passed
+      ? "Yes"
+      : "No";
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-slate-100">Inspector</h2>
+        <button
+          type="button"
+          onClick={() => sessionId && load(sessionId)}
+          disabled={loading}
+          className="rounded bg-slate-700 px-3 py-1 text-xs text-slate-200 hover:bg-slate-600 disabled:cursor-not-allowed"
+        >
+          {loading ? "Refreshing..." : "Refresh"}
+        </button>
+      </div>
+      <div className="rounded border border-slate-800 bg-slate-950/70 p-4 text-sm text-slate-200">
+        <dl className="grid gap-2">
+          <div className="flex justify-between">
+            <dt className="text-slate-400">Attempts</dt>
+            <dd>{summary.attempt_count}</dd>
+          </div>
+          <div className="flex justify-between">
+            <dt className="text-slate-400">Last passed</dt>
+            <dd>{lastPassedText}</dd>
+          </div>
+          <div className="flex justify-between">
+            <dt className="text-slate-400">Last attempt</dt>
+            <dd>
+              {summary.last_attempt_at
+                ? new Date(summary.last_attempt_at).toLocaleString()
+                : "n/a"}
+            </dd>
+          </div>
+        </dl>
+        {Object.keys(summary.metrics ?? {}).length > 0 && (
+          <div className="mt-4 text-xs text-slate-300">
+            <p className="mb-1 font-semibold uppercase tracking-wide text-slate-400">
+              Metrics
+            </p>
+            <pre className="overflow-auto rounded bg-slate-900/80 p-3 text-xs">
+              {JSON.stringify(summary.metrics, null, 2)}
+            </pre>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/labs.ts
+++ b/frontend/src/lib/labs.ts
@@ -30,6 +30,14 @@ export type SessionDetail = {
   attempts: SessionAttempt[];
 };
 
+export type InspectorSummary = {
+  session_id: string;
+  attempt_count: number;
+  last_attempt_at?: string | null;
+  last_passed?: boolean | null;
+  metrics: Record<string, unknown>;
+};
+
 export async function fetchLabs(): Promise<LabSummary[]> {
   return apiGet("/labs");
 }
@@ -40,4 +48,8 @@ export async function fetchLab(slug: string): Promise<LabDetail> {
 
 export async function fetchSession(sessionId: string): Promise<SessionDetail> {
   return apiGet(`/sessions/${sessionId}`);
+}
+
+export async function fetchInspector(sessionId: string): Promise<InspectorSummary> {
+  return apiGet(`/sessions/${sessionId}/inspector`);
 }


### PR DESCRIPTION
fixes #29 
This pull request introduces a new "Inspector" feature that provides a summary of build metrics and attempt statistics for a session, and integrates it into the frontend lab page. The changes span backend API additions, storage enhancements, frontend components, and supporting tests.

**Backend: Inspector API and Storage Enhancements**
- Added a new `InspectorResponse` model and `/sessions/{session_id}/inspector` endpoint to return summary statistics and the latest build metrics for a session. [[1]](diffhunk://#diff-b1aea68deeaa71d65cc595829d06dc0bab4a30b0a97eb551edfc43652166fdd6R78-R85) [[2]](diffhunk://#diff-b1aea68deeaa71d65cc595829d06dc0bab4a30b0a97eb551edfc43652166fdd6R197-R218)
- Implemented a `latest_attempt` method in the `Storage` service to efficiently retrieve the most recent attempt and its metrics for a session.

**Frontend: Inspector Panel Integration**
- Added a new `InspectorPanel` React component that fetches and displays inspector data, including attempt count, last pass status, last attempt date, and metrics.
- Integrated the `InspectorPanel` into the lab page, displaying it alongside other session details. ([frontend/src/app/labs/[slug]/page.tsxR4](diffhunk://#diff-6530a63ce6f905c299fbe1bb014aa5483026173ff08462e7210616b598c255daR4), [frontend/src/app/labs/[slug]/page.tsxR83-R85](diffhunk://#diff-6530a63ce6f905c299fbe1bb014aa5483026173ff08462e7210616b598c255daR83-R85))
- Updated the frontend API library to support fetching inspector summaries and defined the corresponding TypeScript type. [[1]](diffhunk://#diff-7e045c0774032cb3132eeba961d505df80d342bf3c0c9515ae653fa88541433dR33-R40) [[2]](diffhunk://#diff-7e045c0774032cb3132eeba961d505df80d342bf3c0c9515ae653fa88541433dR52-R55)

**Testing**
- Added a test for the new inspector endpoint to verify correct data retrieval and response structure.
- Minor import fix in test file for clarity.