### PR TITLE
feat: add agent stub endpoints and drawer

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,7 +3,7 @@ import os
 import httpx  # type: ignore[import]
 from fastapi import FastAPI, HTTPException  # type: ignore[import]
 
-from .routers import files, labs, sessions, terminal
+from .routers import agent, files, labs, sessions, terminal
 from .services.storage import get_storage
 
 app = FastAPI(title="DockrLearn API")
@@ -14,6 +14,7 @@ app.include_router(labs.router)
 app.include_router(sessions.router)
 app.include_router(files.router)
 app.include_router(terminal.router)
+app.include_router(agent.router)
 
 
 @app.get("/healthz")

--- a/backend/app/routers/agent.py
+++ b/backend/app/routers/agent.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+router = APIRouter(prefix="/agent", tags=["agent"])
+
+
+class AgentRequest(BaseModel):
+    session_id: str = Field(..., description="Active session identifier")
+    prompt: str = Field(..., description="Learner prompt")
+
+
+class AgentResponse(BaseModel):
+    session_id: str
+    prompt: str
+    answer: str
+    source: str = "stub"
+
+
+STUB_HINT = "Remember to install dependencies before building."
+STUB_EXPLAIN = (
+    "Docker builds each instruction in order. Combine related commands to reduce layers "
+    "and cache invalidations."
+)
+
+
+@router.post("/hint", response_model=AgentResponse)
+async def agent_hint(request: AgentRequest) -> AgentResponse:
+    if not request.prompt.strip():
+        raise HTTPException(status_code=400, detail="Prompt cannot be empty")
+    return AgentResponse(
+        session_id=request.session_id,
+        prompt=request.prompt,
+        answer=STUB_HINT,
+    )
+
+
+@router.post("/explain", response_model=AgentResponse)
+async def agent_explain(request: AgentRequest) -> AgentResponse:
+    if not request.prompt.strip():
+        raise HTTPException(status_code=400, detail="Prompt cannot be empty")
+    return AgentResponse(
+        session_id=request.session_id,
+        prompt=request.prompt,
+        answer=STUB_EXPLAIN,
+    )

--- a/backend/tests/test_agent_router.py
+++ b/backend/tests/test_agent_router.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient  # type: ignore[import]
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from backend.app.main import app
+
+client = TestClient(app)
+
+
+def test_hint_endpoint_returns_stub() -> None:
+    response = client.post(
+        "/agent/hint",
+        json={"session_id": "abc", "prompt": "Need a hint"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["answer"]
+    assert payload["session_id"] == "abc"
+
+
+def test_explain_endpoint_rejects_empty_prompt() -> None:
+    response = client.post(
+        "/agent/explain",
+        json={"session_id": "abc", "prompt": "   "},
+    )
+    assert response.status_code == 400

--- a/frontend/src/app/labs/[slug]/page.tsx
+++ b/frontend/src/app/labs/[slug]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { Suspense } from "react";
 import WorkspacePane from "@/components/WorkspacePane";
 import InspectorPanel from "@/components/InspectorPanel";
+import AgentDrawer from "@/components/AgentDrawer";
 import { notFound } from "next/navigation";
 import LabActions from "@/components/LabActions";
 import Terminal from "@/components/Terminal";
@@ -81,10 +82,11 @@ export default async function LabPage({ params, searchParams }: LabPageProps) {
       <LabActions slug={params.slug} initialSession={session} />
       <WorkspacePane sessionId={session?.session_id} />
       <div className="rounded-xl border border-slate-800 bg-slate-900/70 p-6">
-        <InspectorPanel sessionId={session?.session_id} />
-      </div>
-      <div className="rounded-xl border border-slate-800 bg-slate-900/70 p-6">
-        <h2 className="mb-3 text-lg font-semibold text-slate-100">Terminal</h2>
+      <InspectorPanel sessionId={session?.session_id} />
+    </div>
+    <AgentDrawer sessionId={session?.session_id} />
+    <div className="rounded-xl border border-slate-800 bg-slate-900/70 p-6">
+      <h2 className="mb-3 text-lg font-semibold text-slate-100">Terminal</h2>
         <p className="text-sm text-slate-400">
           Connected to session: {session?.session_id ?? "(start a session to use the terminal)"}
         </p>

--- a/frontend/src/components/AgentDrawer.tsx
+++ b/frontend/src/components/AgentDrawer.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import { requestExplain, requestHint } from "@/lib/agent";
+
+export default function AgentDrawer({ sessionId }: { sessionId?: string }) {
+  const [open, setOpen] = useState(false);
+  const [prompt, setPrompt] = useState("");
+  const [answer, setAnswer] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const disabled = !sessionId || loading;
+
+  const sendRequest = async (mode: "hint" | "explain") => {
+    if (!sessionId) {
+      return;
+    }
+    if (!prompt.trim()) {
+      setError("Enter a prompt first.");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const response =
+        mode === "hint"
+          ? await requestHint(sessionId, prompt)
+          : await requestExplain(sessionId, prompt);
+      setAnswer(response.answer);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Agent request failed.";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <aside className="rounded-xl border border-slate-800 bg-slate-900/70 p-4">
+      <button
+        type="button"
+        className="mb-3 text-sm font-semibold text-sky-400 hover:text-sky-300"
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        {open ? "Close Agent" : "Open Agent"}
+      </button>
+      {open && (
+        <div className="space-y-3 text-sm text-slate-200">
+          {!sessionId && (
+            <p className="text-slate-500">Start a session to chat with the agent.</p>
+          )}
+          <textarea
+            value={prompt}
+            onChange={(event) => setPrompt(event.target.value)}
+            placeholder="Ask for a hint or explanation..."
+            className="h-24 w-full rounded border border-slate-800 bg-slate-950 p-2 text-slate-100 placeholder:text-slate-500"
+            disabled={disabled}
+          />
+          <div className="flex gap-3">
+            <button
+              type="button"
+              className="rounded bg-sky-500 px-3 py-2 text-xs font-semibold text-slate-900 disabled:cursor-not-allowed disabled:opacity-60"
+              onClick={() => sendRequest("hint")}
+              disabled={disabled}
+            >
+              {loading ? "Sending..." : "Ask for hint"}
+            </button>
+            <button
+              type="button"
+              className="rounded bg-emerald-500 px-3 py-2 text-xs font-semibold text-emerald-950 disabled:cursor-not-allowed disabled:opacity-60"
+              onClick={() => sendRequest("explain")}
+              disabled={disabled}
+            >
+              {loading ? "Sending..." : "Ask for explain"}
+            </button>
+          </div>
+          {error && <p className="text-red-300">{error}</p>}
+          {answer && (
+            <div className="rounded border border-slate-800 bg-slate-950/70 p-3 text-xs text-slate-200">
+              {answer}
+            </div>
+          )}
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/frontend/src/lib/agent.ts
+++ b/frontend/src/lib/agent.ts
@@ -1,0 +1,21 @@
+import { apiPost } from "@/lib/api";
+
+type AgentPayload = {
+  session_id: string;
+  prompt: string;
+};
+
+type AgentResponse = {
+  session_id: string;
+  prompt: string;
+  answer: string;
+  source: string;
+};
+
+export async function requestHint(sessionId: string, prompt: string): Promise<AgentResponse> {
+  return apiPost("/agent/hint", { session_id: sessionId, prompt });
+}
+
+export async function requestExplain(sessionId: string, prompt: string): Promise<AgentResponse> {
+  return apiPost("/agent/explain", { session_id: sessionId, prompt });
+}


### PR DESCRIPTION
fixes #30 
This pull request introduces a new "agent" feature that enables users to request hints and explanations from an agent, both in the backend and frontend. The changes include new API endpoints, integration with the frontend UI, and supporting tests and utilities.

**Backend: Agent API Endpoints**
- Added a new `agent` router with `/agent/hint` and `/agent/explain` POST endpoints, which accept a prompt and session ID, validate input, and return stubbed responses.
- Registered the new agent router with the FastAPI application in `main.py`. [[1]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3L6-R6) [[2]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3R17)
- Added tests for the agent endpoints to ensure correct behavior for valid and invalid requests.

**Frontend: Agent UI Integration**
- Created a new `AgentDrawer` React component that allows users to interact with the agent by submitting prompts and viewing responses.
- Integrated `AgentDrawer` into the lab page UI, making the agent accessible during lab sessions. ([frontend/src/app/labs/[slug]/page.tsxR5](diffhunk://#diff-6530a63ce6f905c299fbe1bb014aa5483026173ff08462e7210616b598c255daR5), [frontend/src/app/labs/[slug]/page.tsxR87](diffhunk://#diff-6530a63ce6f905c299fbe1bb014aa5483026173ff08462e7210616b598c255daR87))
- Implemented frontend utility functions to call the new backend agent endpoints.