### PR TITLE
feat: improve workspace navigation and editing

### DIFF
--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import base64
 import binascii
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Literal
 
 from fastapi import APIRouter, Depends, HTTPException  # type: ignore[import]
 from pydantic import BaseModel, Field  # type: ignore[import]
@@ -23,6 +23,8 @@ class ListResponseEntry(BaseModel):
 class ListResponse(BaseModel):
     path: str
     entries: List[ListResponseEntry]
+    exists: bool
+    is_dir: bool
 
 
 class ReadResponse(BaseModel):
@@ -39,6 +41,42 @@ class WriteRequest(BaseModel):
 
 
 class WriteResponse(BaseModel):
+    ok: bool
+    path: str
+
+
+class CreateRequest(BaseModel):
+    session_id: str
+    path: str
+    kind: Literal["file", "directory"] = "file"
+    content: str | None = None
+    encoding: str = "base64"
+
+
+class CreateResponse(BaseModel):
+    ok: bool
+    path: str
+    kind: Literal["file", "directory"]
+
+
+class RenameRequest(BaseModel):
+    session_id: str
+    path: str
+    new_path: str
+
+
+class RenameResponse(BaseModel):
+    ok: bool
+    path: str
+    new_path: str
+
+
+class DeleteRequest(BaseModel):
+    session_id: str
+    path: str
+
+
+class DeleteResponse(BaseModel):
     ok: bool
     path: str
 
@@ -60,7 +98,12 @@ async def list_path(
         )
         for item in payload.get("entries", [])
     ]
-    return ListResponse(path=path or "/workspace", entries=entries)
+    return ListResponse(
+        path=payload.get("path", path or "/workspace"),
+        entries=entries,
+        exists=payload.get("exists", True),
+        is_dir=payload.get("is_dir", True),
+    )
 
 
 @router.get("/{session_id}/read", response_model=ReadResponse)
@@ -90,3 +133,46 @@ async def write_file(
         content_b64=request.content,
     )
     return WriteResponse(**payload)
+
+
+@router.post("/create", response_model=CreateResponse)
+async def create_entry(
+    request: CreateRequest,
+    runner: RunnerClient = Depends(get_runner_client),
+) -> CreateResponse:
+    if request.kind == "file":
+        if request.encoding != "base64":
+            raise HTTPException(status_code=400, detail="Only base64 encoding is supported")
+        try:
+            base64.b64decode(request.content or "")
+        except (ValueError, binascii.Error) as exc:  # type: ignore[name-defined]
+            raise HTTPException(status_code=400, detail="Invalid base64 payload") from exc
+    payload = await runner.create_entry(
+        session_id=request.session_id,
+        path=request.path,
+        kind=request.kind,
+        content_b64=request.content if request.kind == "file" else None,
+    )
+    return CreateResponse(**payload)
+
+
+@router.post("/rename", response_model=RenameResponse)
+async def rename_entry(
+    request: RenameRequest,
+    runner: RunnerClient = Depends(get_runner_client),
+) -> RenameResponse:
+    payload = await runner.rename_entry(
+        session_id=request.session_id,
+        path=request.path,
+        new_path=request.new_path,
+    )
+    return RenameResponse(**payload)
+
+
+@router.post("/delete", response_model=DeleteResponse)
+async def delete_entry(
+    request: DeleteRequest,
+    runner: RunnerClient = Depends(get_runner_client),
+) -> DeleteResponse:
+    payload = await runner.delete_entry(session_id=request.session_id, path=request.path)
+    return DeleteResponse(**payload)

--- a/backend/app/services/runner_client.py
+++ b/backend/app/services/runner_client.py
@@ -159,6 +159,40 @@ class RunnerClient:
             response.raise_for_status()
             return response.json()
 
+    async def create_entry(
+        self,
+        session_id: str,
+        *,
+        path: str,
+        kind: str = "file",
+        content_b64: str | None = None,
+    ) -> dict[str, Any]:
+        payload = {
+            "session_id": session_id,
+            "path": path,
+            "kind": kind,
+            "content": content_b64,
+            "encoding": "base64",
+        }
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(f"{self._base_url}/fs/create", json=payload)
+            response.raise_for_status()
+            return response.json()
+
+    async def rename_entry(self, session_id: str, *, path: str, new_path: str) -> dict[str, Any]:
+        payload = {"session_id": session_id, "path": path, "new_path": new_path}
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(f"{self._base_url}/fs/rename", json=payload)
+            response.raise_for_status()
+            return response.json()
+
+    async def delete_entry(self, session_id: str, *, path: str) -> dict[str, Any]:
+        payload = {"session_id": session_id, "path": path}
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(f"{self._base_url}/fs/delete", json=payload)
+            response.raise_for_status()
+            return response.json()
+
 
 def get_runner_client() -> RunnerClient:
     """Convenience dependency for FastAPI injection."""

--- a/backend/tests/test_files_router.py
+++ b/backend/tests/test_files_router.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import base64
-from typing import Any, Dict
+from typing import Any, List, Tuple
 
 import sys
 from pathlib import Path
@@ -18,13 +18,18 @@ from backend.app.services.runner_client import RunnerClient, get_runner_client
 
 class FakeRunner(RunnerClient):
     def __init__(self) -> None:  # pragma: no cover - override base init
-        pass
+        self.created: List[Tuple[str, str]] = []
+        self.renamed: List[Tuple[str, str]] = []
+        self.deleted: List[str] = []
 
     async def list_path(self, session_id: str, path: str | None = None) -> dict[str, Any]:
         return {
+            "path": path or "/workspace",
             "entries": [
                 {"name": "Dockerfile", "path": "/workspace/Dockerfile", "is_dir": False, "size": 42, "modified": 1.0}
             ],
+            "exists": True,
+            "is_dir": True,
         }
 
     async def read_file(self, session_id: str, path: str) -> dict[str, Any]:
@@ -35,6 +40,25 @@ class FakeRunner(RunnerClient):
         }
 
     async def write_file(self, session_id: str, *, path: str, content_b64: str) -> dict[str, Any]:
+        return {"ok": True, "path": path}
+
+    async def create_entry(
+        self,
+        session_id: str,
+        *,
+        path: str,
+        kind: str = "file",
+        content_b64: str | None = None,
+    ) -> dict[str, Any]:
+        self.created.append((path, kind))
+        return {"ok": True, "path": path, "kind": kind}
+
+    async def rename_entry(self, session_id: str, *, path: str, new_path: str) -> dict[str, Any]:
+        self.renamed.append((path, new_path))
+        return {"ok": True, "path": path, "new_path": new_path}
+
+    async def delete_entry(self, session_id: str, *, path: str) -> dict[str, Any]:
+        self.deleted.append(path)
         return {"ok": True, "path": path}
 
 
@@ -51,6 +75,8 @@ def test_list_path_override():
     assert response.status_code == 200
     payload = response.json()
     assert payload["entries"][0]["name"] == "Dockerfile"
+    assert payload["exists"] is True
+    assert payload["is_dir"] is True
     app.dependency_overrides.clear()
 
 
@@ -61,4 +87,59 @@ def test_write_invalid_encoding():
         json={"session_id": "abc", "path": "/workspace/test.txt", "content": "abc", "encoding": "utf-8"},
     )
     assert response.status_code == 400
+    app.dependency_overrides.clear()
+
+
+def test_create_file_request():
+    fake = FakeRunner()
+    app.dependency_overrides[get_runner_client] = lambda: fake
+    response = client.post(
+        "/fs/create",
+        json={
+            "session_id": "abc",
+            "path": "/workspace/new.txt",
+            "kind": "file",
+            "content": base64.b64encode(b"data").decode("ascii"),
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["path"] == "/workspace/new.txt"
+    assert fake.created == [("/workspace/new.txt", "file")]
+    app.dependency_overrides.clear()
+
+
+def test_create_directory_request():
+    fake = FakeRunner()
+    app.dependency_overrides[get_runner_client] = lambda: fake
+    response = client.post(
+        "/fs/create",
+        json={"session_id": "abc", "path": "/workspace/new", "kind": "directory"},
+    )
+    assert response.status_code == 200
+    assert fake.created == [("/workspace/new", "directory")]
+    app.dependency_overrides.clear()
+
+
+def test_rename_request():
+    fake = FakeRunner()
+    app.dependency_overrides[get_runner_client] = lambda: fake
+    response = client.post(
+        "/fs/rename",
+        json={"session_id": "abc", "path": "/workspace/old.txt", "new_path": "/workspace/new.txt"},
+    )
+    assert response.status_code == 200
+    assert fake.renamed == [("/workspace/old.txt", "/workspace/new.txt")]
+    app.dependency_overrides.clear()
+
+
+def test_delete_request():
+    fake = FakeRunner()
+    app.dependency_overrides[get_runner_client] = lambda: fake
+    response = client.post(
+        "/fs/delete",
+        json={"session_id": "abc", "path": "/workspace/delete.txt"},
+    )
+    assert response.status_code == 200
+    assert fake.deleted == ["/workspace/delete.txt"]
     app.dependency_overrides.clear()

--- a/frontend/src/components/FileExplorer.tsx
+++ b/frontend/src/components/FileExplorer.tsx
@@ -1,63 +1,432 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { listPath, type ListResponse } from "@/lib/fs";
+import {
+  createEntry,
+  deleteEntry,
+  FsEntry,
+  listPath,
+  renameEntry,
+} from "@/lib/fs";
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+const WORKSPACE_ROOT = "/workspace";
+
+type EntryKind = "file" | "directory";
+
+export type FileExplorerHandle = {
+  refresh: (path?: string) => Promise<void>;
+};
 
 export type FileExplorerProps = {
   sessionId?: string;
-  onSelect: (path: string, isDir: boolean) => void;
+  activeFile?: string;
+  activeDirectory: string;
+  dirtyPaths: Set<string>;
+  onSelectFile: (path: string) => void;
+  onSelectDirectory: (path: string) => void;
+  onEntryCreated: (path: string, kind: EntryKind) => void;
+  onEntryRenamed: (oldPath: string, newPath: string) => void;
+  onEntryDeleted: (path: string) => void;
 };
 
-export default function FileExplorer({ sessionId, onSelect }: FileExplorerProps) {
-  const [listing, setListing] = useState<ListResponse | null>(null);
-  const [error, setError] = useState<string | null>(null);
+type EntryMap = Record<string, FsEntry[]>;
 
-  useEffect(() => {
-    if (!sessionId) {
-      setListing(null);
-      setError(null);
-      return;
-    }
-    listPath(sessionId)
-      .then((data) => {
-        setListing(data);
-        setError(null);
-      })
-      .catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : "Unable to list files";
-        setError(message);
-      });
-  }, [sessionId]);
-
-  if (!sessionId) {
-    return <p className="text-sm text-slate-500">Start a session to explore files.</p>;
+function parentPath(path: string): string {
+  if (!path || path === WORKSPACE_ROOT) {
+    return WORKSPACE_ROOT;
   }
-
-  if (error) {
-    return <p className="text-sm text-red-300">{error}</p>;
+  const trimmed = path.replace(/\/$/, "");
+  const lastSlash = trimmed.lastIndexOf("/");
+  if (lastSlash <= 0) {
+    return WORKSPACE_ROOT;
   }
-
-  if (!listing) {
-    return <p className="text-sm text-slate-400">Loading files...</p>;
-  }
-
-  return (
-    <div className="space-y-2 text-sm text-slate-200">
-      <div className="font-semibold text-slate-100">Workspace</div>
-      <ul className="max-h-64 overflow-auto rounded border border-slate-800 bg-slate-950/80">
-        {listing.entries.map((entry) => (
-          <li
-            key={entry.path}
-            className="flex cursor-pointer items-center justify-between border-b border-slate-900 px-3 py-2 last:border-b-0 hover:bg-slate-800/60"
-            onClick={() => onSelect(entry.path, entry.is_dir)}
-          >
-            <span>{entry.is_dir ? `📁 ${entry.name}` : `📄 ${entry.name}`}</span>
-            {typeof entry.size === "number" && !entry.is_dir ? (
-              <span className="text-xs text-slate-500">{entry.size} B</span>
-            ) : null}
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
+  const parent = trimmed.slice(0, lastSlash);
+  return parent || WORKSPACE_ROOT;
 }
+
+function joinPath(directory: string, name: string): string {
+  const base = directory.endsWith("/") ? directory.slice(0, -1) : directory;
+  return `${base}/${name}`;
+}
+
+function isDescendent(base: string, candidate: string): boolean {
+  if (base === candidate) {
+    return true;
+  }
+  const prefix = base.endsWith("/") ? base : `${base}/`;
+  return candidate.startsWith(prefix);
+}
+
+function formatDirtyIndicator(dirtyPaths: Set<string>, entryPath: string, isDirectory: boolean): boolean {
+  if (dirtyPaths.has(entryPath)) {
+    return true;
+  }
+  if (!isDirectory) {
+    return false;
+  }
+  let descendantDirty = false;
+  dirtyPaths.forEach((dirty) => {
+    if (!descendantDirty && isDescendent(entryPath, dirty)) {
+      descendantDirty = true;
+    }
+  });
+  return descendantDirty;
+}
+
+const FileExplorer = forwardRef<FileExplorerHandle, FileExplorerProps>(
+  (
+    {
+      sessionId,
+      activeFile,
+      activeDirectory,
+      dirtyPaths,
+      onSelectFile,
+      onSelectDirectory,
+      onEntryCreated,
+      onEntryRenamed,
+      onEntryDeleted,
+    },
+    ref
+  ) => {
+    const [entriesByPath, setEntriesByPath] = useState<EntryMap>({});
+    const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set([WORKSPACE_ROOT]));
+    const [loadingPaths, setLoadingPaths] = useState<Set<string>>(new Set());
+    const [error, setError] = useState<string | null>(null);
+
+    const sessionRef = useRef<string | undefined>();
+    sessionRef.current = sessionId;
+
+    const setLoading = useCallback((path: string, next: boolean) => {
+      setLoadingPaths((prev) => {
+        const updated = new Set(prev);
+        if (next) {
+          updated.add(path);
+        } else {
+          updated.delete(path);
+        }
+        return updated;
+      });
+    }, []);
+
+    const updateEntryMap = useCallback((path: string, entries: FsEntry[]) => {
+      setEntriesByPath((prev) => ({
+        ...prev,
+        [path]: entries,
+      }));
+    }, []);
+
+    const removeEntryTree = useCallback((target: string) => {
+      setEntriesByPath((prev) => {
+        const next: EntryMap = {};
+        const prefix = target.endsWith("/") ? target : `${target}/`;
+        for (const [key, value] of Object.entries(prev)) {
+          if (key === target || key.startsWith(prefix)) {
+            continue;
+          }
+          next[key] = value;
+        }
+        return next;
+      });
+    }, []);
+
+    const fetchEntries = useCallback(
+      async (path: string): Promise<void> => {
+        if (!sessionId) {
+          return;
+        }
+        setLoading(path, true);
+        try {
+          const response = await listPath(sessionId, path === WORKSPACE_ROOT ? undefined : path);
+          if (sessionRef.current !== sessionId) {
+            return;
+          }
+          updateEntryMap(response.path, response.entries);
+          setError(null);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : "Unable to list files";
+          setError(message);
+        } finally {
+          setLoading(path, false);
+        }
+      },
+      [sessionId, setLoading, updateEntryMap]
+    );
+
+    useEffect(() => {
+      setEntriesByPath({});
+      setExpandedPaths(new Set([WORKSPACE_ROOT]));
+      setError(null);
+      if (sessionId) {
+        void fetchEntries(WORKSPACE_ROOT);
+      }
+    }, [fetchEntries, sessionId]);
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        async refresh(path?: string) {
+          const target = path ?? WORKSPACE_ROOT;
+          await fetchEntries(target);
+        },
+      }),
+      [fetchEntries]
+    );
+
+    const toggleDirectory = useCallback(
+      (path: string) => {
+        setExpandedPaths((prev) => {
+          const next = new Set(prev);
+          if (next.has(path)) {
+            next.delete(path);
+          } else {
+            next.add(path);
+            if (!entriesByPath[path]) {
+              void fetchEntries(path);
+            }
+          }
+          return next;
+        });
+      },
+      [entriesByPath, fetchEntries]
+    );
+
+    const handleCreate = useCallback(
+      async (kind: EntryKind) => {
+        if (!sessionId) {
+          return;
+        }
+        const baseDirectory = activeDirectory || WORKSPACE_ROOT;
+        const promptLabel = kind === "file" ? "Enter file name" : "Enter folder name";
+        const name = window.prompt(promptLabel, "");
+        if (!name) {
+          return;
+        }
+        const sanitized = name.trim();
+        if (!sanitized) {
+          return;
+        }
+        const fullPath = joinPath(baseDirectory, sanitized);
+        try {
+          await createEntry(sessionId, fullPath, kind, "");
+          await fetchEntries(baseDirectory);
+          if (kind === "directory") {
+            setExpandedPaths((prev) => new Set(prev).add(fullPath));
+          }
+          onEntryCreated(fullPath, kind);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : `Failed to create ${kind}.`;
+          setError(message);
+        }
+      },
+      [activeDirectory, fetchEntries, onEntryCreated, sessionId]
+    );
+
+    const handleRename = useCallback(
+      async (entry: FsEntry) => {
+        if (!sessionId) {
+          return;
+        }
+        const baseDirectory = parentPath(entry.path);
+        const suggested = entry.name;
+        const nextName = window.prompt(`Rename ${entry.is_dir ? "folder" : "file"}`, suggested);
+        if (!nextName) {
+          return;
+        }
+        const trimmed = nextName.trim();
+        if (!trimmed || trimmed === suggested) {
+          return;
+        }
+        const newPath = joinPath(baseDirectory, trimmed);
+        try {
+          await renameEntry(sessionId, entry.path, newPath);
+          await fetchEntries(baseDirectory);
+          if (entry.is_dir) {
+            removeEntryTree(entry.path);
+            setExpandedPaths((prev) => {
+              const next = new Set(prev);
+              if (next.has(entry.path)) {
+                next.delete(entry.path);
+                next.add(newPath);
+              }
+              return next;
+            });
+          }
+          onEntryRenamed(entry.path, newPath);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : "Failed to rename.";
+          setError(message);
+        }
+      },
+      [fetchEntries, onEntryRenamed, removeEntryTree, sessionId]
+    );
+
+    const handleDelete = useCallback(
+      async (entry: FsEntry) => {
+        if (!sessionId) {
+          return;
+        }
+        const confirmed = window.confirm(`Delete ${entry.is_dir ? "folder" : "file"} '${entry.name}'?`);
+        if (!confirmed) {
+          return;
+        }
+        const baseDirectory = parentPath(entry.path);
+        try {
+          await deleteEntry(sessionId, entry.path);
+          await fetchEntries(baseDirectory);
+          removeEntryTree(entry.path);
+          onEntryDeleted(entry.path);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : "Failed to delete.";
+          setError(message);
+        }
+      },
+      [fetchEntries, onEntryDeleted, removeEntryTree, sessionId]
+    );
+
+    const directoryEntries = useMemo(() => entriesByPath[WORKSPACE_ROOT] ?? [], [entriesByPath]);
+    const isLoadingRoot = loadingPaths.has(WORKSPACE_ROOT);
+
+    const renderEntries = useCallback(
+      (path: string, depth: number): JSX.Element | null => {
+        const entries = entriesByPath[path];
+        if (!entries || entries.length === 0) {
+          return null;
+        }
+        const sorted = [...entries].sort((a, b) => {
+          if (a.is_dir === b.is_dir) {
+            return a.name.localeCompare(b.name);
+          }
+          return a.is_dir ? -1 : 1;
+        });
+
+        return (
+          <ul>
+            {sorted.map((entry) => {
+              const isExpanded = expandedPaths.has(entry.path);
+              const isLoading = loadingPaths.has(entry.path);
+              const isActiveFile = entry.path === activeFile;
+              const isActiveDirectory = entry.path === activeDirectory;
+              const showDirtyIndicator = formatDirtyIndicator(dirtyPaths, entry.path, entry.is_dir);
+              return (
+                <li key={entry.path}>
+                  <div
+                    className={`flex items-center gap-2 px-2 py-1 text-sm ${
+                      isActiveFile || isActiveDirectory
+                        ? "bg-slate-800/70 text-slate-100"
+                        : "hover:bg-slate-800/40"
+                    }`}
+                    style={{ paddingLeft: depth * 12 }}
+                  >
+                    {entry.is_dir ? (
+                      <button
+                        type="button"
+                        onClick={() => toggleDirectory(entry.path)}
+                        className="text-slate-400 transition hover:text-slate-200"
+                        aria-label={isExpanded ? "Collapse folder" : "Expand folder"}
+                      >
+                        {isExpanded ? "▾" : "▸"}
+                      </button>
+                    ) : (
+                      <span className="w-3" />
+                    )}
+                    <button
+                      type="button"
+                      className={`flex-1 text-left ${entry.is_dir ? "font-medium" : ""}`}
+                      onClick={() =>
+                        entry.is_dir ? onSelectDirectory(entry.path) : onSelectFile(entry.path)
+                      }
+                    >
+                      {entry.is_dir ? "📁" : "📄"} {entry.name}
+                      {showDirtyIndicator && <span className="ml-1 text-xs text-amber-300">●</span>}
+                    </button>
+                    {isLoading && <span className="text-xs text-slate-400">…</span>}
+                    <div className="flex gap-1 text-xs">
+                      <button
+                        type="button"
+                        className="rounded px-2 py-1 text-slate-400 hover:bg-slate-800/80 hover:text-slate-100"
+                        onClick={() => handleRename(entry)}
+                      >
+                        Rename
+                      </button>
+                      <button
+                        type="button"
+                        className="rounded px-2 py-1 text-red-300 hover:bg-red-500/10"
+                        onClick={() => handleDelete(entry)}
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+                  {entry.is_dir && isExpanded && renderEntries(entry.path, depth + 1)}
+                </li>
+              );
+            })}
+          </ul>
+        );
+      },
+      [
+        activeDirectory,
+        activeFile,
+        dirtyPaths,
+        entriesByPath,
+        expandedPaths,
+        handleDelete,
+        handleRename,
+        loadingPaths,
+        onSelectDirectory,
+        onSelectFile,
+        toggleDirectory,
+      ]
+    );
+
+    if (!sessionId) {
+      return <p className="text-sm text-slate-500">Start a session to explore files.</p>;
+    }
+
+    return (
+      <div className="space-y-3 text-sm text-slate-200">
+        <div className="flex items-center justify-between">
+          <div className="font-semibold text-slate-100">Workspace</div>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              className="rounded bg-slate-800 px-3 py-1 text-xs text-slate-200 hover:bg-slate-700"
+              onClick={() => handleCreate("file")}
+            >
+              New File
+            </button>
+            <button
+              type="button"
+              className="rounded bg-slate-800 px-3 py-1 text-xs text-slate-200 hover:bg-slate-700"
+              onClick={() => handleCreate("directory")}
+            >
+              New Folder
+            </button>
+          </div>
+        </div>
+        {error && <p className="text-xs text-red-300">{error}</p>}
+        <div className="max-h-72 overflow-auto rounded border border-slate-800 bg-slate-950/80">
+          {isLoadingRoot && !directoryEntries.length ? (
+            <p className="px-3 py-2 text-xs text-slate-400">Loading files...</p>
+          ) : directoryEntries.length === 0 ? (
+            <p className="px-3 py-2 text-xs text-slate-400">This workspace is empty.</p>
+          ) : (
+            renderEntries(WORKSPACE_ROOT, 0)
+          )}
+        </div>
+      </div>
+    );
+  }
+);
+
+FileExplorer.displayName = "FileExplorer";
+
+export default FileExplorer;

--- a/frontend/src/components/WorkspacePane.tsx
+++ b/frontend/src/components/WorkspacePane.tsx
@@ -1,30 +1,286 @@
 "use client";
 
-import { useState } from "react";
-import FileExplorer from "@/components/FileExplorer";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import FileExplorer, { FileExplorerHandle } from "@/components/FileExplorer";
 import EditorPane from "@/components/EditorPane";
+
+const WORKSPACE_ROOT = "/workspace";
 
 type Props = {
   sessionId?: string;
 };
 
+type Breadcrumb = {
+  label: string;
+  path: string;
+  isFile: boolean;
+};
+
+function parentPath(path: string | undefined): string {
+  if (!path || path === WORKSPACE_ROOT) {
+    return WORKSPACE_ROOT;
+  }
+  const trimmed = path.replace(/\/$/, "");
+  const lastSlash = trimmed.lastIndexOf("/");
+  if (lastSlash <= 0) {
+    return WORKSPACE_ROOT;
+  }
+  const parent = trimmed.slice(0, lastSlash);
+  return parent || WORKSPACE_ROOT;
+}
+
+function joinPath(directory: string, name: string): string {
+  const base = directory.endsWith("/") ? directory.slice(0, -1) : directory;
+  return `${base}/${name}`;
+}
+
+function isDescendant(base: string, candidate: string): boolean {
+  if (base === candidate) {
+    return true;
+  }
+  const prefix = base.endsWith("/") ? base : `${base}/`;
+  return candidate.startsWith(prefix);
+}
+
 export default function WorkspacePane({ sessionId }: Props) {
-  const [selectedPath, setSelectedPath] = useState<string | undefined>();
+  const explorerRef = useRef<FileExplorerHandle | null>(null);
+  const [activeFile, setActiveFile] = useState<string | undefined>();
+  const [activeDirectory, setActiveDirectory] = useState<string>(WORKSPACE_ROOT);
+  const [dirtyPaths, setDirtyPaths] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    setActiveFile(undefined);
+    setActiveDirectory(WORKSPACE_ROOT);
+    setDirtyPaths(new Set());
+  }, [sessionId]);
+
+  const confirmNavigation = useCallback(
+    (targetPath: string): boolean => {
+      if (!activeFile) {
+        return true;
+      }
+      if (targetPath === activeFile) {
+        return true;
+      }
+      if (!dirtyPaths.has(activeFile)) {
+        return true;
+      }
+      return window.confirm("You have unsaved changes. Continue without saving?");
+    },
+    [activeFile, dirtyPaths]
+  );
+
+  const handleSelectFile = useCallback(
+    (path: string) => {
+      if (!confirmNavigation(path)) {
+        return;
+      }
+      setActiveFile(path);
+      setActiveDirectory(parentPath(path));
+    },
+    [confirmNavigation]
+  );
+
+  const handleSelectDirectory = useCallback(
+    (path: string) => {
+      if (!confirmNavigation(path)) {
+        return;
+      }
+      setActiveFile(undefined);
+      setActiveDirectory(path);
+    },
+    [confirmNavigation]
+  );
+
+  const handleEntryCreated = useCallback(
+    (path: string, kind: "file" | "directory") => {
+      if (kind === "file") {
+        if (!confirmNavigation(path)) {
+          return;
+        }
+        setActiveFile(path);
+        setActiveDirectory(parentPath(path));
+      } else {
+        if (!confirmNavigation(path)) {
+          return;
+        }
+        setActiveFile(undefined);
+        setActiveDirectory(path);
+      }
+      setDirtyPaths((prev) => {
+        const next = new Set(prev);
+        next.delete(path);
+        return next;
+      });
+    },
+    [confirmNavigation]
+  );
+
+  const handleEntryRenamed = useCallback(
+    (oldPath: string, newPath: string) => {
+      setDirtyPaths((prev) => {
+        const next = new Set<string>();
+        prev.forEach((dirty) => {
+          if (dirty === oldPath) {
+            return;
+          }
+          if (isDescendant(oldPath, dirty)) {
+            return;
+          }
+          next.add(dirty);
+        });
+        return next;
+      });
+
+      setActiveFile((prev) => {
+        if (!prev) {
+          return prev;
+        }
+        if (prev === oldPath) {
+          return newPath;
+        }
+        if (isDescendant(oldPath, prev)) {
+          return prev.replace(oldPath, newPath);
+        }
+        return prev;
+      });
+
+      setActiveDirectory((prev) => {
+        if (!prev) {
+          return prev;
+        }
+        if (prev === oldPath) {
+          return newPath;
+        }
+        if (isDescendant(oldPath, prev)) {
+          return prev.replace(oldPath, newPath);
+        }
+        return prev;
+      });
+    },
+    []
+  );
+
+  const handleEntryDeleted = useCallback((path: string) => {
+    setDirtyPaths((prev) => {
+      const next = new Set<string>();
+      prev.forEach((dirty) => {
+        if (!isDescendant(path, dirty)) {
+          next.add(dirty);
+        }
+      });
+      return next;
+    });
+
+    setActiveFile((prev) => {
+      if (prev && isDescendant(path, prev)) {
+        return undefined;
+      }
+      return prev;
+    });
+
+    setActiveDirectory((prev) => {
+      if (prev && isDescendant(path, prev)) {
+        return parentPath(path);
+      }
+      return prev;
+    });
+  }, []);
+
+  const handleDirtyChange = useCallback((path: string | undefined, dirty: boolean) => {
+    if (!path) {
+      return;
+    }
+    setDirtyPaths((prev) => {
+      const next = new Set(prev);
+      if (dirty) {
+        next.add(path);
+      } else {
+        next.delete(path);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleSave = useCallback((path: string) => {
+    setDirtyPaths((prev) => {
+      const next = new Set(prev);
+      next.delete(path);
+      return next;
+    });
+    const directory = parentPath(path);
+    void explorerRef.current?.refresh(directory);
+  }, []);
+
+  const currentTarget = activeFile ?? activeDirectory;
+  const breadcrumbs = useMemo(() => {
+    const parts: Breadcrumb[] = [{ label: "workspace", path: WORKSPACE_ROOT, isFile: false }];
+    if (!currentTarget || currentTarget === WORKSPACE_ROOT) {
+      return parts;
+    }
+    const relative = currentTarget
+      .replace(WORKSPACE_ROOT, "")
+      .replace(/^\/+/, "")
+      .split("/")
+      .filter(Boolean);
+    let accumulator = WORKSPACE_ROOT;
+    relative.forEach((segment, index) => {
+      accumulator = joinPath(accumulator, segment);
+      const isLast = index === relative.length - 1;
+      const isFile = Boolean(activeFile) && isLast;
+      parts.push({ label: segment, path: accumulator, isFile });
+    });
+    return parts;
+  }, [activeFile, currentTarget]);
 
   return (
-    <div className="grid gap-6 md:grid-cols-[280px_1fr]">
+    <div className="grid gap-6 md:grid-cols-[300px_1fr]">
       <div className="rounded-xl border border-slate-800 bg-slate-900/70 p-4">
         <FileExplorer
+          ref={explorerRef}
           sessionId={sessionId}
-          onSelect={(path, isDir) => {
-            if (!isDir) {
-              setSelectedPath(path);
-            }
-          }}
+          activeFile={activeFile}
+          activeDirectory={activeDirectory}
+          dirtyPaths={dirtyPaths}
+          onSelectFile={handleSelectFile}
+          onSelectDirectory={handleSelectDirectory}
+          onEntryCreated={handleEntryCreated}
+          onEntryRenamed={handleEntryRenamed}
+          onEntryDeleted={handleEntryDeleted}
         />
       </div>
-      <div className="rounded-xl border border-slate-800 bg-slate-900/70 p-4">
-        <EditorPane sessionId={sessionId} path={selectedPath} />
+      <div className="space-y-4 rounded-xl border border-slate-800 bg-slate-900/70 p-4">
+        <nav className="flex flex-wrap items-center gap-2 text-xs text-slate-400">
+          {breadcrumbs.map((crumb, index) => {
+            const isLast = index === breadcrumbs.length - 1;
+            if (isLast || crumb.isFile) {
+              return (
+                <span key={crumb.path} className="flex items-center gap-2">
+                  <span className="font-medium text-slate-200">{crumb.label}</span>
+                  {!isLast && <span>/</span>}
+                </span>
+              );
+            }
+            return (
+              <span key={crumb.path} className="flex items-center gap-2">
+                <button
+                  type="button"
+                  className="text-sky-400 hover:text-sky-300"
+                  onClick={() => handleSelectDirectory(crumb.path)}
+                >
+                  {crumb.label}
+                </button>
+                {!isLast && <span>/</span>}
+              </span>
+            );
+          })}
+        </nav>
+        <EditorPane
+          sessionId={sessionId}
+          path={activeFile}
+          onDirtyChange={handleDirtyChange}
+          onSave={handleSave}
+        />
       </div>
     </div>
   );

--- a/frontend/src/lib/fs.ts
+++ b/frontend/src/lib/fs.ts
@@ -1,6 +1,6 @@
 import { apiGet, apiPost } from "@/lib/api";
 
-type FsEntry = {
+export type FsEntry = {
   name: string;
   path: string;
   is_dir: boolean;
@@ -11,6 +11,8 @@ type FsEntry = {
 export type ListResponse = {
   path: string;
   entries: FsEntry[];
+  exists: boolean;
+  is_dir: boolean;
 };
 
 export async function listPath(sessionId: string, path?: string): Promise<ListResponse> {
@@ -41,6 +43,40 @@ export async function writeFile(
     path,
     content: contentBase64,
     encoding: "base64",
+  });
+}
+
+export async function createEntry(
+  sessionId: string,
+  path: string,
+  kind: "file" | "directory",
+  contentBase64?: string
+): Promise<void> {
+  await apiPost(`/fs/create`, {
+    session_id: sessionId,
+    path,
+    kind,
+    content: kind === "file" ? contentBase64 ?? "" : undefined,
+    encoding: "base64",
+  });
+}
+
+export async function renameEntry(
+  sessionId: string,
+  path: string,
+  newPath: string
+): Promise<void> {
+  await apiPost(`/fs/rename`, {
+    session_id: sessionId,
+    path,
+    new_path: newPath,
+  });
+}
+
+export async function deleteEntry(sessionId: string, path: string): Promise<void> {
+  await apiPost(`/fs/delete`, {
+    session_id: sessionId,
+    path,
   });
 }
 


### PR DESCRIPTION
fixes #37 
This pull request introduces several enhancements and new features to the file management system, both in the backend and frontend. The most significant changes are the addition of create, rename, and delete file/directory operations in the backend API, and the implementation of improved file state management (including dirty state tracking and navigation confirmation) in the frontend workspace and editor components. Comprehensive tests have also been added for the new backend endpoints.

**Backend API Enhancements:**

* Added new endpoints and request/response models for creating, renaming, and deleting files and directories (`CreateRequest`, `RenameRequest`, `DeleteRequest`, etc.) in `files.py`, and implemented corresponding API handlers. [[1]](diffhunk://#diff-229ff4f25e0305e32ea9e6631a8506b8964b09baa5847e1409af4fc7c23c79eaR48-R83) [[2]](diffhunk://#diff-229ff4f25e0305e32ea9e6631a8506b8964b09baa5847e1409af4fc7c23c79eaR136-R178)
* Updated the `RunnerClient` service to support `create_entry`, `rename_entry`, and `delete_entry` methods, enabling the backend to communicate these operations to the underlying runner service.
* Extended the file listing response to include `exists` and `is_dir` fields, providing more detailed information about file system entries. [[1]](diffhunk://#diff-229ff4f25e0305e32ea9e6631a8506b8964b09baa5847e1409af4fc7c23c79eaR26-R27) [[2]](diffhunk://#diff-229ff4f25e0305e32ea9e6631a8506b8964b09baa5847e1409af4fc7c23c79eaL63-R106)

**Frontend File and Editor State Management:**

* Refactored `WorkspacePane` to manage active file/directory state, track dirty (unsaved) files, and prompt for confirmation when navigating away from unsaved changes. Breadcrumb navigation and state updates on file operations are now supported.
* Enhanced `EditorPane` to notify parent components of dirty state changes and successful saves via new `onDirtyChange` and `onSave` callbacks, and to reset state appropriately on file changes. [[1]](diffhunk://#diff-2e9c6dbbca46d69ed22d567184f7194cf8fdd0ac46ec815555991c3d1dd1bec6R12-R49) [[2]](diffhunk://#diff-2e9c6dbbca46d69ed22d567184f7194cf8fdd0ac46ec815555991c3d1dd1bec6R58-R65) [[3]](diffhunk://#diff-2e9c6dbbca46d69ed22d567184f7194cf8fdd0ac46ec815555991c3d1dd1bec6R74-R75) [[4]](diffhunk://#diff-2e9c6dbbca46d69ed22d567184f7194cf8fdd0ac46ec815555991c3d1dd1bec6R114)

**Testing Improvements:**

* Added comprehensive tests for the new backend endpoints (create, rename, delete) in `test_files_router.py`, including validation of state changes in the fake runner.
* Updated the fake runner and related tests to support and verify the new file management operations and extended response fields. [[1]](diffhunk://#diff-ae69b59d2a6506ff67bcc2e2d9d937b2b578a28ede0c790f3998d8f9d06b49adL21-R32) [[2]](diffhunk://#diff-ae69b59d2a6506ff67bcc2e2d9d937b2b578a28ede0c790f3998d8f9d06b49adR45-R63) [[3]](diffhunk://#diff-ae69b59d2a6506ff67bcc2e2d9d937b2b578a28ede0c790f3998d8f9d06b49adR78-R79)

These changes collectively enable robust file and directory management from the frontend, with improved user experience around unsaved changes and navigation, and ensure correctness with thorough backend testing.