### PR TITLE
feat: add lab3 multi-stage build challenge

### DIFF
--- a/backend/app/services/judge_service.py
+++ b/backend/app/services/judge_service.py
@@ -5,7 +5,7 @@ from typing import Any, Awaitable, Callable, Dict
 from fastapi import HTTPException
 
 from judge import JudgeResult
-from judge.labs import evaluate_lab1, evaluate_lab2
+from judge.labs import evaluate_lab1, evaluate_lab2, evaluate_lab3
 from .runner_client import RunnerClient
 
 
@@ -19,6 +19,7 @@ class JudgeService:
         self._handlers: Dict[str, LabHandler] = {
             "lab1": evaluate_lab1,
             "lab2": evaluate_lab2,
+            "lab3": evaluate_lab3,
         }
 
     async def evaluate(self, lab_slug: str, session_id: str, runner: RunnerClient) -> JudgeResult:

--- a/backend/tests/test_judge_lab3.py
+++ b/backend/tests/test_judge_lab3.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Optional
+
+import sys
+from pathlib import Path
+
+import httpx  # type: ignore[import]
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from judge.labs.lab3 import evaluate  # noqa: E402
+
+
+SUCCESS_DOCKERFILE = """
+FROM node:20-bullseye AS builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+EXPOSE 8080
+CMD [\"npm\", \"start\"]
+"""
+
+SINGLE_STAGE_DOCKERFILE = """
+FROM node:20
+WORKDIR /app
+COPY . .
+RUN npm install && npm run build
+CMD [\"npm\", \"start\"]
+"""
+
+ALIAS_MISSING_DOCKERFILE = """
+FROM node:20
+WORKDIR /app
+RUN npm install
+FROM node:20-alpine
+COPY . .
+EXPOSE 8080
+CMD [\"npm\", \"start\"]
+"""
+
+MISSING_COPY_DOCKERFILE = """
+FROM node:20 AS builder
+WORKDIR /app
+COPY . .
+RUN npm install && npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+COPY . .
+CMD [\"npm\", \"start\"]
+"""
+
+
+class FakeRunner:
+    def __init__(
+        self,
+        *,
+        dockerfile: str,
+        image_size_mb: float = 120.0,
+        build_success: bool = True,
+        health_success: bool = True,
+    ) -> None:
+        self._dockerfile = dockerfile
+        self._build_success = build_success
+        self._health_success = health_success
+        self._image_size_mb = image_size_mb
+        self.exec_invocations: list[list[str]] = []
+
+    async def exec(
+        self,
+        session_id: str,
+        *,
+        command: list[str],
+        workdir: str | None = None,
+        environment: Dict[str, str] | None = None,
+    ) -> Dict[str, Any]:
+        joined = " ".join(command)
+        self.exec_invocations.append(command)
+        if "cat /workspace/Dockerfile" in joined:
+            return {"exit_code": 0, "logs": self._dockerfile.strip().splitlines()}
+        if "curl" in joined:
+            status = "200" if self._health_success else "500"
+            exit_code = 0 if self._health_success else 7
+            return {"exit_code": exit_code, "logs": [status]}
+        raise AssertionError(f"Unexpected exec command: {command}")
+
+    async def build(
+        self,
+        session_id: str,
+        *,
+        context_path: str = "/workspace",
+        dockerfile_path: str = "Dockerfile",
+        image_tag: str | None = None,
+        build_args: Dict[str, str] | None = None,
+    ) -> Dict[str, Any]:
+        if not self._build_success:
+            response = httpx.Response(
+                status_code=500,
+                json={"error": "docker build failed", "logs": ["boom"]},
+                request=httpx.Request("POST", "http://runner/build"),
+            )
+            raise httpx.HTTPStatusError("boom", request=response.request, response=response)
+        return {
+            "image_tag": image_tag,
+            "logs": ["build log"],
+            "metrics": {
+                "image_size_mb": self._image_size_mb,
+                "elapsed_seconds": 12.3,
+                "layer_count": 8,
+            },
+        }
+
+    async def run(
+        self,
+        session_id: str,
+        *,
+        image: str,
+        command: list[str] | None = None,
+        env: Dict[str, str] | None = None,
+        ports: list[str] | None = None,
+        name: str | None = None,
+        detach: bool = True,
+        auto_remove: bool = False,
+        remove_existing: bool = True,
+    ) -> Dict[str, Any]:
+        return {
+            "container_name": "rl_app_test",
+            "logs": ["running"],
+            "elapsed_seconds": 0.25,
+        }
+
+    async def stop_run(
+        self,
+        session_id: str,
+        *,
+        container_name: str | None = None,
+        timeout: int = 10,
+        remove: bool = True,
+        ignore_missing: bool = True,
+    ) -> Dict[str, Any]:
+        return {"ok": True, "stopped": True, "removed": True, "logs": []}
+
+
+def test_lab3_success() -> None:
+    runner = FakeRunner(dockerfile=SUCCESS_DOCKERFILE)
+    result = asyncio.run(evaluate("session", runner))
+    assert result.passed is True
+    assert not result.failures
+    assert result.metrics["build"]["image_size_mb"] == runner._image_size_mb
+
+
+def test_lab3_single_stage_rejected() -> None:
+    runner = FakeRunner(dockerfile=SINGLE_STAGE_DOCKERFILE)
+    result = asyncio.run(evaluate("session", runner))
+    assert result.passed is False
+    assert any(failure.code == "single_stage" for failure in result.failures)
+
+
+def test_lab3_alias_missing_rejected() -> None:
+    runner = FakeRunner(dockerfile=ALIAS_MISSING_DOCKERFILE)
+    result = asyncio.run(evaluate("session", runner))
+    assert result.passed is False
+    assert any(failure.code == "builder_alias_missing" for failure in result.failures)
+
+
+def test_lab3_missing_copy_from_rejected() -> None:
+    runner = FakeRunner(dockerfile=MISSING_COPY_DOCKERFILE)
+    result = asyncio.run(evaluate("session", runner))
+    assert result.passed is False
+    assert any(failure.code == "copy_from_missing" for failure in result.failures)
+
+
+def test_lab3_image_size_rejected() -> None:
+    runner = FakeRunner(dockerfile=SUCCESS_DOCKERFILE, image_size_mb=300.0)
+    result = asyncio.run(evaluate("session", runner))
+    assert result.passed is False
+    assert any(failure.code == "image_too_large" for failure in result.failures)
+
+
+def test_lab3_health_failure() -> None:
+    runner = FakeRunner(dockerfile=SUCCESS_DOCKERFILE, health_success=False)
+    result = asyncio.run(evaluate("session", runner))
+    assert result.passed is False
+    assert any(failure.code == "healthcheck_failed" for failure in result.failures)

--- a/judge/labs/__init__.py
+++ b/judge/labs/__init__.py
@@ -1,2 +1,3 @@
 from .lab1 import evaluate as evaluate_lab1  # noqa: F401
 from .lab2 import evaluate as evaluate_lab2  # noqa: F401
+from .lab3 import evaluate as evaluate_lab3  # noqa: F401

--- a/judge/labs/lab3.py
+++ b/judge/labs/lab3.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import httpx  # type: ignore[import]
+
+from judge.models import JudgeResult
+from .lab1 import (  # noqa: F401 - reuse RunnerProtocol utilities
+    DEFAULT_PORT,
+    HEALTH_PATH,
+    RunnerProtocol,
+    _probe_health,
+    _safe_stop,
+    _extract_runner_detail,
+)
+
+MAX_IMAGE_MB = 250.0
+
+
+async def evaluate(session_id: str, runner: RunnerProtocol) -> JudgeResult:
+    result = JudgeResult(passed=True)
+
+    dockerfile = await _read_dockerfile(session_id, runner, result)
+    builder_alias = _validate_multistage(dockerfile, result) if dockerfile else None
+
+    build_info = await _attempt_build(session_id, runner, result)
+    if not build_info:
+        return result
+
+    run_info = await _exercise_container(session_id, runner, result)
+    if run_info:
+        result.metrics.setdefault("run", {})["elapsed_seconds"] = run_info.get("elapsed_seconds")
+
+    return result
+
+
+async def _read_dockerfile(session_id: str, runner: RunnerProtocol, result: JudgeResult) -> str | None:
+    response = await runner.exec(
+        session_id=session_id,
+        command=["sh", "-lc", "cat /workspace/Dockerfile"],
+    )
+    if response.get("exit_code", 1) != 0:
+        result.add_failure(
+            code="dockerfile_missing",
+            message="Missing Dockerfile in the workspace.",
+            hint="Place a Dockerfile at the repository root and ensure the filename is capitalised.",
+        )
+        return None
+    return "\n".join(response.get("logs", []))
+
+
+def _validate_multistage(contents: str, result: JudgeResult) -> str | None:
+    lines = _normalise_instructions(contents)
+    from_lines = [line for line in lines if line.lower().startswith("from ")]
+    if len(from_lines) < 2:
+        result.add_failure(
+            code="single_stage",
+            message="Use a multi-stage Dockerfile so build tooling stays out of the final image.",
+            hint="Add a builder stage (e.g. `FROM node:20 AS builder`) and copy only the artefacts you need into the runtime stage.",
+        )
+        return None
+
+    builder_line = from_lines[0]
+    builder_alias = _extract_alias(builder_line)
+    if builder_alias is None:
+        result.add_failure(
+            code="builder_alias_missing",
+            message="Name the first stage so you can COPY artefacts from it.",
+            hint="Add `AS builder` (or similar) to the first FROM instruction.",
+        )
+        return None
+
+    if not _has_copy_from(lines, builder_alias):
+        result.add_failure(
+            code="copy_from_missing",
+            message="Copy artefacts from the builder stage rather than rebuilding in the runtime image.",
+            hint=f"Use `COPY --from={builder_alias} ...` to bring built assets into the final stage.",
+        )
+
+    return builder_alias
+
+
+async def _attempt_build(session_id: str, runner: RunnerProtocol, result: JudgeResult) -> Dict[str, Any] | None:
+    image_tag = f"containrlab/lab3-{session_id[:12]}"
+    try:
+        build_response = await runner.build(
+            session_id=session_id,
+            context_path="/workspace",
+            dockerfile_path="Dockerfile",
+            image_tag=image_tag,
+        )
+    except httpx.HTTPStatusError as exc:
+        detail = _extract_runner_detail(exc)
+        hint = detail.get("hint") if isinstance(detail, dict) else None
+        logs = detail.get("logs") if isinstance(detail, dict) else None
+        if logs:
+            result.notes.setdefault("build_logs", logs)
+        result.add_failure(
+            code="docker_build_failed",
+            message="Docker build failed inside the runner.",
+            hint=hint or (detail.get("error") if isinstance(detail, dict) else str(exc)),
+        )
+        return None
+    except httpx.HTTPError as exc:
+        result.add_failure(
+            code="runner_unavailable",
+            message="Failed to contact runner while building the image.",
+            hint=str(exc),
+        )
+        return None
+
+    metrics = build_response.get("metrics", {})
+    result.metrics["build"] = metrics
+    result.metrics["image_tag"] = build_response.get("image_tag") or image_tag
+    result.notes.setdefault("build_logs", build_response.get("logs", []))
+
+    size_mb = metrics.get("image_size_mb")
+    if size_mb is not None and size_mb >= MAX_IMAGE_MB:
+        size_str = f"{float(size_mb):.2f}"
+        result.add_failure(
+            code="image_too_large",
+            message=f"Final image is too large ({size_str} MB). Aim for under {MAX_IMAGE_MB:.0f} MB.",
+            hint="Move dev dependencies and build tooling to the builder stage and copy only the compiled output into the runtime image.",
+        )
+
+    return build_response
+
+
+async def _exercise_container(session_id: str, runner: RunnerProtocol, result: JudgeResult) -> Dict[str, Any] | None:
+    image_tag = result.metrics.get("image_tag")
+    if not image_tag:
+        image_tag = f"containrlab/lab3-{session_id[:12]}"
+
+    container_name: str | None = None
+    try:
+        run_response = await runner.run(
+            session_id=session_id,
+            image=image_tag,
+            command=[],
+            ports=[f"{DEFAULT_PORT}:{DEFAULT_PORT}"],
+            detach=True,
+            auto_remove=False,
+            remove_existing=True,
+        )
+        container_name = run_response.get("container_name")
+        if not await _probe_health(session_id, runner):
+            result.add_failure(
+                code="healthcheck_failed",
+                message=f"Container failed to respond on http://localhost:{DEFAULT_PORT}{HEALTH_PATH}.",
+                hint="Ensure the app listens on port 8080 and keeps the /health endpoint returning 200.",
+            )
+        return run_response
+    except httpx.HTTPStatusError as exc:
+        detail = _extract_runner_detail(exc)
+        hint = detail.get("hint") if isinstance(detail, dict) else None
+        logs = detail.get("logs") if isinstance(detail, dict) else None
+        if logs:
+            result.notes.setdefault("runtime_logs", logs)
+        result.add_failure(
+            code="docker_run_failed",
+            message="docker run failed inside the runner.",
+            hint=hint or (detail.get("error") if isinstance(detail, dict) else str(exc)),
+        )
+        return None
+    except httpx.HTTPError as exc:
+        result.add_failure(
+            code="runner_unavailable",
+            message="Failed to contact runner while running the container.",
+            hint=str(exc),
+        )
+        return None
+    finally:
+        if container_name:
+            await _safe_stop(session_id, runner, container_name)
+
+
+def _normalise_instructions(contents: str) -> List[str]:
+    instructions: List[str] = []
+    for raw in contents.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        instructions.append(line)
+    return instructions
+
+
+def _extract_alias(from_instruction: str) -> str | None:
+    tokens = from_instruction.split()
+    lowered = [token.lower() for token in tokens]
+    if "as" in lowered:
+        index = lowered.index("as")
+        if index + 1 < len(tokens):
+            return tokens[index + 1]
+    return None
+
+
+def _has_copy_from(lines: List[str], alias: str) -> bool:
+    alias_lower = alias.lower()
+    for line in lines:
+        if line.lower().startswith("copy") and f"--from={alias_lower}" in line.lower():
+            return True
+    return False

--- a/labs/lab3/README.md
+++ b/labs/lab3/README.md
@@ -1,0 +1,19 @@
+# Lab 3: Multi-Stage Builds
+
+Level up your Docker skills by converting the starter image into a lean multi-stage build. The sample app is a small Express server that serves a `/health` endpoint. The current Dockerfile installs everything in a single stage which leaves development dependencies and build tooling inside the final image.
+
+## Your Goals
+
+1. **Split the Dockerfile into at least two stages.** Name the first stage `builder` (or similar) and keep dependency installs and build tooling there.
+2. **Produce a slim runtime image.** Copy only the compiled `dist/` output and the production dependencies into the final stage. Aim for an image smaller than **250&nbsp;MB**.
+3. **Expose the server correctly.** The container should continue to listen on port `8080` and run `npm start`.
+4. **Keep the health endpoint working.** `curl http://localhost:8080/health` must return `200`.
+
+## Tips
+
+- Install dependencies reproducibly in the builder stage (`npm install` is fine; add a lockfile if you prefer `npm ci`). In the runtime stage install only production dependencies (e.g. `npm install --omit=dev`).
+- `npm run build` already emits the compiled assets into `dist/`.
+- Alpine or distroless base images keep the final image small, but remember Node distroless images do not ship with `/bin/sh`.
+- If you copy the whole project in the runtime stage, the image will still be large—copy only what you need.
+
+Good luck! When the judge runs, it will fail if the Dockerfile is still single-stage, if the final image is too large, or if the health endpoint stops responding.

--- a/labs/lab3/starter/.dockerignore
+++ b/labs/lab3/starter/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log
+Dockerfile
+.git
+.gitignore
+dist

--- a/labs/lab3/starter/Dockerfile
+++ b/labs/lab3/starter/Dockerfile
@@ -1,0 +1,13 @@
+# TODO: Convert this single-stage image into a lean multi-stage build
+FROM node:20-bullseye
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm install
+
+COPY . .
+RUN npm run build
+
+EXPOSE 8080
+CMD ["npm", "start"]

--- a/labs/lab3/starter/package.json
+++ b/labs/lab3/starter/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "containrlab-lab3",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "typescript": "^5.4.5"
+  }
+}

--- a/labs/lab3/starter/src/server.ts
+++ b/labs/lab3/starter/src/server.ts
@@ -1,0 +1,16 @@
+import express from "express";
+
+const app = express();
+const PORT = process.env.PORT ?? 8080;
+
+app.get("/", (_req, res) => {
+  res.json({ message: "ContainrLab Lab 3" });
+});
+
+app.get("/health", (_req, res) => {
+  res.json({ ok: true });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/labs/lab3/starter/tsconfig.json
+++ b/labs/lab3/starter/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/scripts/runnerd_smoke.py
+++ b/scripts/runnerd_smoke.py
@@ -1,6 +1,7 @@
 """Local smoke test for runnerd start/stop endpoints.
 
 Run with: `python scripts/runnerd_smoke.py` while docker compose stack is up.
+Specify a different lab slug (e.g. `lab3`) by passing it as the first argument.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
fixes #41 
This pull request introduces Lab 3, focusing on multi-stage Docker builds, and integrates its evaluation into the backend judge service. The major changes include the implementation of the Lab 3 judge logic, new test coverage for Lab 3, and the addition of the Lab 3 starter project with supporting documentation and configuration.

**Lab 3 Judge Implementation and Integration:**

* Added `evaluate_lab3` to the judge service and handler registry, enabling Lab 3 submissions to be evaluated (`backend/app/services/judge_service.py`, `judge/labs/__init__.py`). [[1]](diffhunk://#diff-85dce1d559b8aa51fc83ea0e9de7a99bd5b97cf7b7e7276149dc295d9c895f47L8-R8) [[2]](diffhunk://#diff-85dce1d559b8aa51fc83ea0e9de7a99bd5b97cf7b7e7276149dc295d9c895f47R22) [[3]](diffhunk://#diff-1318bd685c121c9bf9f85d420c23b8723bca390d97d54aaf4e2ad0d4e007f6e0R3)
* Implemented `judge/labs/lab3.py`, introducing multi-stage Dockerfile validation, image size enforcement, and runtime health checks for Lab 3.

**Testing and Validation:**

* Added comprehensive tests for Lab 3 judge logic, covering multi-stage validation, builder alias checks, image size, and health endpoint behavior (`backend/tests/test_judge_lab3.py`).

**Lab 3 Starter Project and Documentation:**

* Introduced Lab 3 starter project, including:
  - A single-stage Dockerfile as a starting point (`labs/lab3/starter/Dockerfile`).
  - Express server in TypeScript (`labs/lab3/starter/src/server.ts`).
  - Project configuration files: `package.json`, `tsconfig.json`, and `.dockerignore` for best practices (`labs/lab3/starter/package.json`, `labs/lab3/starter/tsconfig.json`, `labs/lab3/starter/.dockerignore`). [[1]](diffhunk://#diff-c146ee4f2465e85e7843fb31cde3b9481b9675a708814e8fed44aa5c825d4ffeR1-R16) [[2]](diffhunk://#diff-b1360305be3bea2f8ea1065ca52439a57e5885e29b80a156ed5d3805539546d5R1-R14) [[3]](diffhunk://#diff-2e0f82f4a82b8a4730404a6ed8f4844eed4bddd8d6738774f432c80378d4fc1eR1-R6)
* Added a detailed README explaining the goals and requirements for Lab 3 (`labs/lab3/README.md`).

**Miscellaneous:**

* Updated the runner smoke test script to allow specifying the lab slug as an argument (`scripts/runnerd_smoke.py`).