### PR TITLE
feat: enrich inspector with cache and layer metrics

### DIFF
--- a/frontend/src/lib/labs.ts
+++ b/frontend/src/lib/labs.ts
@@ -36,6 +36,8 @@ export type InspectorSummary = {
   last_attempt_at?: string | null;
   last_passed?: boolean | null;
   metrics: Record<string, unknown>;
+  previous_metrics?: Record<string, unknown> | null;
+  metric_deltas?: Record<string, number>;
 };
 
 export async function fetchLabs(): Promise<LabSummary[]> {


### PR DESCRIPTION
fixes #42 
This pull request enhances the build metrics system by adding support for comparing metrics between build attempts, exposing metric deltas, and improving the frontend display of these metrics. It also expands the collected build metrics to include layer details and cache hits, and updates the backend and frontend to handle and present this richer information.

**Backend: Metrics Comparison and Collection Improvements**
- The backend now computes and returns the differences ("deltas") between the latest and previous build metrics, allowing users to see how metrics have changed between attempts. It also exposes previous metrics in the API response. [[1]](diffhunk://#diff-b1aea68deeaa71d65cc595829d06dc0bab4a30b0a97eb551edfc43652166fdd6R84-R85) [[2]](diffhunk://#diff-b1aea68deeaa71d65cc595829d06dc0bab4a30b0a97eb551edfc43652166fdd6L209-R251)
- The build metrics collected during image creation now include cache hit counts and detailed information about each build layer (such as layer size and command), enabling deeper analysis of build performance and structure. [[1]](diffhunk://#diff-38c48b07125f94f3401ed793bdbc1fba118a7d23d852015458a356478a806bf6L222-R222) [[2]](diffhunk://#diff-38c48b07125f94f3401ed793bdbc1fba118a7d23d852015458a356478a806bf6L655-R661) [[3]](diffhunk://#diff-38c48b07125f94f3401ed793bdbc1fba118a7d23d852015458a356478a806bf6L669-R695)

**Frontend: Enhanced Metrics Display**
- The `InspectorPanel` component is updated to display build metrics in a user-friendly table, including metric deltas (with visual indicators) when a previous attempt exists. It also lists build layers with their sizes and commands, making it easier to understand build composition and changes over time. [[1]](diffhunk://#diff-9474fb63ef0e8306a4bf450aca31490bba63baa2b48e0e3475ca83eb241f3135L6-R47) [[2]](diffhunk://#diff-9474fb63ef0e8306a4bf450aca31490bba63baa2b48e0e3475ca83eb241f3135R98-R160) [[3]](diffhunk://#diff-9474fb63ef0e8306a4bf450aca31490bba63baa2b48e0e3475ca83eb241f3135L82-R230)
- The frontend data model is updated to support the new `previous_metrics` and `metric_deltas` fields from the backend.

**Testing**
- The test suite is updated to cover multiple build attempts, nested metrics, and the new metric delta logic, ensuring correctness of the new features. [[1]](diffhunk://#diff-a69f19c5fe726e728bd9174caaee337d6ef917b008e285d41faffad670a88d9bL77-R87) [[2]](diffhunk://#diff-a69f19c5fe726e728bd9174caaee337d6ef917b008e285d41faffad670a88d9bL86-R99)