### PR TITLE
Implement session TTL enforcement

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,14 +1,24 @@
+import asyncio
+import contextlib
+import logging
 import os
+from datetime import datetime, timedelta, timezone
 
 import httpx  # type: ignore[import]
 from fastapi import FastAPI, HTTPException  # type: ignore[import]
 
 from .routers import agent, files, labs, sessions, terminal
 from .services.storage import get_storage
+from .services.runner_client import get_runner_client
 
 app = FastAPI(title="DockrLearn API")
 
 RUNNERD_BASE_URL = os.getenv("RUNNERD_BASE_URL", "http://runnerd:8080")
+SESSION_CLEANUP_INTERVAL_SECONDS = float(os.getenv("SESSION_CLEANUP_INTERVAL_SECONDS", "60"))
+SESSION_TTL_GRACE_SECONDS = int(os.getenv("SESSION_TTL_GRACE_SECONDS", "120"))
+
+logger = logging.getLogger("containrlab.session_cleanup")
+_cleanup_task: asyncio.Task[None] | None = None
 
 app.include_router(labs.router)
 app.include_router(sessions.router)
@@ -39,3 +49,66 @@ async def runnerd_healthz() -> dict:
 @app.on_event("startup")
 async def _startup() -> None:
     get_storage()
+    _start_session_cleanup()
+
+
+@app.on_event("shutdown")
+async def _shutdown() -> None:
+    await _stop_session_cleanup()
+
+
+def _start_session_cleanup() -> None:
+    global _cleanup_task
+    if _cleanup_task is not None:
+        return
+    loop = asyncio.get_event_loop()
+    _cleanup_task = loop.create_task(_session_cleanup_loop())
+
+
+async def _stop_session_cleanup() -> None:
+    global _cleanup_task
+    if _cleanup_task is None:
+        return
+    _cleanup_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await _cleanup_task
+    _cleanup_task = None
+
+
+async def _session_cleanup_loop() -> None:
+    interval = max(1.0, SESSION_CLEANUP_INTERVAL_SECONDS)
+    try:
+        while True:
+            await _perform_session_cleanup()
+            await asyncio.sleep(interval)
+    except asyncio.CancelledError:
+        raise
+    except Exception:  # pragma: no cover - defensive guard
+        logger.exception("Unexpected error in session cleanup loop")
+
+
+async def _perform_session_cleanup() -> None:
+    storage = get_storage()
+    cutoff = datetime.now(timezone.utc) - timedelta(seconds=max(0, SESSION_TTL_GRACE_SECONDS))
+    expired_sessions = storage.list_expired_sessions(before=cutoff)
+    if not expired_sessions:
+        return
+
+    runner = get_runner_client()
+    for entry in expired_sessions:
+        session_id = entry["session_id"]
+        mark_ended = False
+        try:
+            await runner.stop(session_id=session_id, preserve_workspace=False)
+            mark_ended = True
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            if status in {404, 409, 410}:
+                mark_ended = True
+            logger.warning("Failed to stop expired session %s (status %s): %s", session_id, status, exc)
+        except httpx.HTTPError as exc:
+            logger.warning("Failed to contact runner for expired session %s: %s", session_id, exc)
+        else:
+            logger.info("Stopped expired session %s", session_id)
+        if mark_ended:
+            storage.mark_session_ended(session_id=session_id)

--- a/backend/app/routers/labs.py
+++ b/backend/app/routers/labs.py
@@ -22,6 +22,7 @@ class LabStartResponse(BaseModel):
     session_id: str
     ttl: int
     runner_container: str
+    expires_at: str
 
 
 class LabListItem(BaseModel):
@@ -73,7 +74,7 @@ async def start_lab(
         raise HTTPException(status_code=502, detail="Runner response missing container reference")
 
     try:
-        storage.record_session(
+        session_record = storage.record_session(
             session_id=session_id,
             lab_slug=lab_slug,
             runner_container=container_name,
@@ -82,7 +83,13 @@ async def start_lab(
     except StorageError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    return LabStartResponse(session_id=session_id, ttl=SESSION_TTL_SECONDS, runner_container=container_name)
+    expires_at = session_record["expires_at"]
+    return LabStartResponse(
+        session_id=session_id,
+        ttl=SESSION_TTL_SECONDS,
+        runner_container=container_name,
+        expires_at=expires_at,
+    )
 
 
 @router.get("", response_model=list[LabListItem])

--- a/backend/app/routers/sessions.py
+++ b/backend/app/routers/sessions.py
@@ -72,6 +72,8 @@ class SessionDetailResponse(BaseModel):
     runner_container: str
     ttl_seconds: int
     created_at: str
+    expires_at: str
+    ended_at: str | None = None
     attempts: list[AttemptEntry]
 
 
@@ -194,6 +196,8 @@ async def get_session_detail(
         runner_container=session["runner_container"],
         ttl_seconds=session["ttl_seconds"],
         created_at=session["created_at"],
+        expires_at=session["expires_at"],
+        ended_at=session.get("ended_at"),
         attempts=attempt_models,
     )
 

--- a/backend/tests/test_sessions_router.py
+++ b/backend/tests/test_sessions_router.py
@@ -40,6 +40,8 @@ def test_get_session_detail_returns_attempts(tmp_path: Path) -> None:
     payload = response.json()
     assert payload["session_id"] == session_id
     assert payload["lab_slug"] == "lab1"
+    assert "expires_at" in payload
+    assert payload["ended_at"] is None
     assert len(payload["attempts"]) == 1
     assert payload["attempts"][0]["metrics"]["idx"] == 1
 

--- a/frontend/src/lib/labs.ts
+++ b/frontend/src/lib/labs.ts
@@ -27,6 +27,8 @@ export type SessionDetail = {
   runner_container: string;
   ttl_seconds: number;
   created_at: string;
+  expires_at: string;
+  ended_at?: string | null;
   attempts: SessionAttempt[];
 };
 


### PR DESCRIPTION
fixes #50 
This pull request implements robust session expiration tracking and automatic cleanup for lab sessions, along with exposing session expiry information through the API and frontend. It introduces background cleanup of expired sessions, extends the session storage schema, and updates the frontend to display session expiry and prevent actions on expired sessions.

**Backend: Session Expiry Tracking and Cleanup**

- **Session expiration and cleanup logic:**
  - Adds `expires_at` and `ended_at` fields to the session storage schema, with migration support for existing databases. Sessions now have an explicit expiration timestamp, and ended sessions are tracked. [[1]](diffhunk://#diff-45f32c11fc1beff332c751541f06e2559d48393d657016c4ce1741ed3bea3448L58-R60) [[2]](diffhunk://#diff-45f32c11fc1beff332c751541f06e2559d48393d657016c4ce1741ed3bea3448R78-R79)
  - Implements a background asyncio task that periodically checks for and cleans up expired sessions, stopping their containers and marking them as ended. This task starts on application startup and stops on shutdown. [[1]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3R1-R21) [[2]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3R52-R114)
  - Adds methods to list expired sessions and to mark sessions as ended in the storage layer.

- **API changes:**
  - The session creation and detail endpoints now include `expires_at` and `ended_at` fields in their responses, allowing clients to know when sessions will expire or have ended. [[1]](diffhunk://#diff-a870e78cf9bb173290ba31e711741a88b4b91384342c2d089c7457c2877f3a88R25) [[2]](diffhunk://#diff-b1aea68deeaa71d65cc595829d06dc0bab4a30b0a97eb551edfc43652166fdd6R75-R76) [[3]](diffhunk://#diff-a870e78cf9bb173290ba31e711741a88b4b91384342c2d089c7457c2877f3a88L76-R77) [[4]](diffhunk://#diff-a870e78cf9bb173290ba31e711741a88b4b91384342c2d089c7457c2877f3a88L85-R92) [[5]](diffhunk://#diff-b1aea68deeaa71d65cc595829d06dc0bab4a30b0a97eb551edfc43652166fdd6R199-R200)

**Frontend: Session Expiry Awareness**

- **Session expiry UX improvements:**
  - Displays a countdown to session expiry and the expiry time in the UI, with color-coded warnings as expiry approaches or after expiration. [[1]](diffhunk://#diff-8913cd56f5c33cb5ad1bb8e519f8141ca833f1979c6a08926ec46444ac14ce16R90) [[2]](diffhunk://#diff-8913cd56f5c33cb5ad1bb8e519f8141ca833f1979c6a08926ec46444ac14ce16R101-R133) [[3]](diffhunk://#diff-8913cd56f5c33cb5ad1bb8e519f8141ca833f1979c6a08926ec46444ac14ce16R268-R286)
  - Disables the "Run judge" button and blocks judge attempts if the session has expired, prompting the user to start a new session. [[1]](diffhunk://#diff-8913cd56f5c33cb5ad1bb8e519f8141ca833f1979c6a08926ec46444ac14ce16R182-R188) [[2]](diffhunk://#diff-8913cd56f5c33cb5ad1bb8e519f8141ca833f1979c6a08926ec46444ac14ce16L217-R300)
  - Adds a utility to format durations for display.

**Testing and Validation**

- **Expanded test coverage:**
  - Adds and updates tests to verify session expiry fields, session cleanup, and marking sessions as ended. [[1]](diffhunk://#diff-7a3924d6af8b340109d5f78eaa8003843f0912d3c62c182cbf92875cffbb7d2dR30-R31) [[2]](diffhunk://#diff-7a3924d6af8b340109d5f78eaa8003843f0912d3c62c182cbf92875cffbb7d2dR48-R52) [[3]](diffhunk://#diff-7a3924d6af8b340109d5f78eaa8003843f0912d3c62c182cbf92875cffbb7d2dR93-R115) [[4]](diffhunk://#diff-a69f19c5fe726e728bd9174caaee337d6ef917b008e285d41faffad670a88d9bR43-R44)

These changes ensure that expired sessions are automatically cleaned up, users are informed about session expiry, and actions are prevented on expired sessions, improving reliability and user experience.

- Backend: Session expiration and cleanup
  * Adds `expires_at` and `ended_at` fields to session storage, with migration for existing databases. [[1]](diffhunk://#diff-45f32c11fc1beff332c751541f06e2559d48393d657016c4ce1741ed3bea3448L58-R60) [[2]](diffhunk://#diff-45f32c11fc1beff332c751541f06e2559d48393d657016c4ce1741ed3bea3448R78-R79)
  * Implements periodic background cleanup of expired sessions, stopping containers and marking sessions as ended. [[1]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3R1-R21) [[2]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3R52-R114) [[3]](diffhunk://#diff-45f32c11fc1beff332c751541f06e2559d48393d657016c4ce1741ed3bea3448R211-R247)
- API changes
  * Exposes `expires_at` and `ended_at` in session creation and detail responses. [[1]](diffhunk://#diff-a870e78cf9bb173290ba31e711741a88b4b91384342c2d089c7457c2877f3a88R25) [[2]](diffhunk://#diff-b1aea68deeaa71d65cc595829d06dc0bab4a30b0a97eb551edfc43652166fdd6R75-R76) [[3]](diffhunk://#diff-a870e78cf9bb173290ba31e711741a88b4b91384342c2d089c7457c2877f3a88L76-R77) [[4]](diffhunk://#diff-a870e78cf9bb173290ba31e711741a88b4b91384342c2d089c7457c2877f3a88L85-R92) [[5]](diffhunk://#diff-b1aea68deeaa71d65cc595829d06dc0bab4a30b0a97eb551edfc43652166fdd6R199-R200)
- Frontend: Session expiry UX
  * Shows session expiry countdown and disables actions on expired sessions, with user feedback. [[1]](diffhunk://#diff-8913cd56f5c33cb5ad1bb8e519f8141ca833f1979c6a08926ec46444ac14ce16R90) [[2]](diffhunk://#diff-8913cd56f5c33cb5ad1bb8e519f8141ca833f1979c6a08926ec46444ac14ce16R101-R133) [[3]](diffhunk://#diff-8913cd56f5c33cb5ad1bb8e519f8141ca833f1979c6a08926ec46444ac14ce16R268-R286) [[4]](diffhunk://#diff-8913cd56f5c33cb5ad1bb8e519f8141ca833f1979c6a08926ec46444ac14ce16R182-R188) [[5]](diffhunk://#diff-8913cd56f5c33cb5ad1bb8e519f8141ca833f1979c6a08926ec46444ac14ce16L217-R300) [[6]](diffhunk://#diff-8913cd56f5c33cb5ad1bb8e519f8141ca833f1979c6a08926ec46444ac14ce16R14-R36)
- Testing
  * Adds/updates tests for session expiry, cleanup, and marking sessions as ended. [[1]](diffhunk://#diff-7a3924d6af8b340109d5f78eaa8003843f0912d3c62c182cbf92875cffbb7d2dR30-R31) [[2]](diffhunk://#diff-7a3924d6af8b340109d5f78eaa8003843f0912d3c62c182cbf92875cffbb7d2dR48-R52) [[3]](diffhunk://#diff-7a3924d6af8b340109d5f78eaa8003843f0912d3c62c182cbf92875cffbb7d2dR93-R115) [[4]](diffhunk://#diff-a69f19c5fe726e728bd9174caaee337d6ef917b008e285d41faffad670a88d9bR43-R44)