### PR TITLE
Add inspector attempt timeline view

### DIFF
--- a/backend/tests/test_sessions_router.py
+++ b/backend/tests/test_sessions_router.py
@@ -115,5 +115,8 @@ def test_inspector_endpoint(tmp_path: Path) -> None:
     assert payload["previous_metrics"]["build"]["image_size_mb"] == 48.0
     assert payload["metric_deltas"]["build.image_size_mb"] == -5.9
     assert payload["last_passed"] is False
+    assert len(payload["timeline"]) == 2
+    assert payload["timeline"][0]["metrics"]["image_size_mb"] == 42.1
+    assert payload["timeline"][0]["deltas"]["image_size_mb"] == -5.9
 
     app.dependency_overrides.clear()

--- a/frontend/src/lib/labs.ts
+++ b/frontend/src/lib/labs.ts
@@ -40,6 +40,22 @@ export type InspectorSummary = {
   metrics: Record<string, unknown>;
   previous_metrics?: Record<string, unknown> | null;
   metric_deltas?: Record<string, number>;
+  timeline?: InspectorTimelineEntry[];
+};
+
+export type InspectorTimelineEntry = {
+  attempt_id: number;
+  created_at: string;
+  passed: boolean;
+  metrics: {
+    elapsed_seconds?: number;
+    image_size_mb?: number;
+    cache_hits?: number;
+    layer_count?: number;
+    [key: string]: number | undefined;
+  };
+  deltas?: Record<string, number>;
+  notes?: Record<string, unknown>;
 };
 
 export async function fetchLabs(): Promise<LabSummary[]> {


### PR DESCRIPTION
fixes #54 
This pull request introduces a build attempt timeline feature to the session inspector, allowing users to view detailed metrics and changes for each build attempt in both the backend and frontend. The changes include backend logic to compute and expose a timeline of build metrics and frontend components to display this timeline in the UI.

**Backend changes:**

* Added computation and exposure of a timeline of build attempts, including per-attempt metrics and their deltas, in the session inspector API. [[1]](diffhunk://#diff-b1aea68deeaa71d65cc595829d06dc0bab4a30b0a97eb551edfc43652166fdd6R89) [[2]](diffhunk://#diff-b1aea68deeaa71d65cc595829d06dc0bab4a30b0a97eb551edfc43652166fdd6R239-R240) [[3]](diffhunk://#diff-b1aea68deeaa71d65cc595829d06dc0bab4a30b0a97eb551edfc43652166fdd6R249) [[4]](diffhunk://#diff-b1aea68deeaa71d65cc595829d06dc0bab4a30b0a97eb551edfc43652166fdd6R276-R325)
* Updated backend tests to verify the timeline data is present and correct in API responses.

**Frontend changes:**

* Extended the inspector summary and timeline types to support the new timeline data structure.
* Updated the `InspectorPanel` to display a timeline of build attempts, showing metrics, deltas, and notes for each attempt, and refactored metric display logic to support this. [[1]](diffhunk://#diff-9474fb63ef0e8306a4bf450aca31490bba63baa2b48e0e3475ca83eb241f3135L5-R6) [[2]](diffhunk://#diff-9474fb63ef0e8306a4bf450aca31490bba63baa2b48e0e3475ca83eb241f3135L15-R17) [[3]](diffhunk://#diff-9474fb63ef0e8306a4bf450aca31490bba63baa2b48e0e3475ca83eb241f3135R57-R58) [[4]](diffhunk://#diff-9474fb63ef0e8306a4bf450aca31490bba63baa2b48e0e3475ca83eb241f3135L205-R181) [[5]](diffhunk://#diff-9474fb63ef0e8306a4bf450aca31490bba63baa2b48e0e3475ca83eb241f3135R220-R332)

These changes provide users with greater visibility into how build metrics evolve across attempts, making it easier to track performance and diagnose issues.