### PR TITLE
fixed agent going to fallback instead of gemini

### DIFF
--- a/backend/app/services/agent_service.py
+++ b/backend/app/services/agent_service.py
@@ -19,9 +19,9 @@ def _log(level: int, message: str, metadata: Dict[str, Any], **extra: Any) -> No
     payload = {**metadata, **extra}
     logger.log(level, message, extra=payload)
 
-DEFAULT_MODEL = os.getenv("GEMINI_MODEL", "models/gemini-1.5-flash")
+DEFAULT_MODEL = os.getenv("GEMINI_MODEL", "models/gemini-flash-latest")
 DEFAULT_TEMPERATURE = float(os.getenv("GEMINI_TEMPERATURE", "0.7"))
-DEFAULT_MAX_OUTPUT_TOKENS = int(os.getenv("GEMINI_MAX_OUTPUT_TOKENS", "512"))
+DEFAULT_MAX_OUTPUT_TOKENS = int(os.getenv("GEMINI_MAX_OUTPUT_TOKENS", "2048"))
 DEFAULT_TIMEOUT_SECONDS = float(os.getenv("GEMINI_TIMEOUT_SECONDS", "20"))
 
 FALLBACK_HINT = "Remember to install dependencies before building."

--- a/docs/LOCAL_RUNBOOK.md
+++ b/docs/LOCAL_RUNBOOK.md
@@ -21,6 +21,7 @@ This guide walks through standing up the full ContainrLab stack on a single deve
 2. **Provide a Gemini API key (optional but recommended)**
    - Follow the instructions in [`docs/GEMINI_SETUP.md`](./GEMINI_SETUP.md) to place your key in `compose/secrets/GEMINI_API_KEY.txt` or export `GEMINI_API_KEY`.
    - Without a key the agent will fall back to deterministic stub responses. The UI will still function, including patch suggestions, thanks to the built-in fallback.
+   - The stack now targets `models/gemini-flash-latest` by default. If your API key does not have access to that model, override it by setting `GEMINI_MODEL` before running `docker compose up`.
 
 3. **Bring the stack online**
    ```bash

--- a/runner/supervisor/server.py
+++ b/runner/supervisor/server.py
@@ -340,7 +340,7 @@ async def terminal_websocket(websocket: WebSocket, session_id: str, shell: str =
                 while not stop_event.is_set():
                     data = await loop.run_in_executor(None, raw_sock.recv, 4096)
                     if not data:
-                        print("runner sock closed", session_id)
+                        logger.debug("terminal socket closed session=%s", session_id)
                         break
                     await websocket.send_text(data.decode("utf-8", errors="ignore"))
             except Exception as exc:
@@ -365,7 +365,7 @@ async def terminal_websocket(websocket: WebSocket, session_id: str, shell: str =
                         payload = {"type": "input", "data": message}
 
                     msg_type = payload.get("type")
-                    print("runner inbound", session_id, msg_type, payload)
+                    logger.debug("terminal inbound session=%s type=%s", session_id, msg_type)
                     if msg_type == "input":
                         data = payload.get("data", "")
                         if isinstance(data, str) and data:
@@ -375,7 +375,7 @@ async def terminal_websocket(websocket: WebSocket, session_id: str, shell: str =
                         rows = payload.get("rows")
                         if isinstance(cols, int) and isinstance(rows, int):
                             try:
-                                print("runner resize", session_id, cols, rows)
+                                logger.debug("terminal resize session=%s cols=%s rows=%s", session_id, cols, rows)
                                 container.client.api.exec_resize(  # type: ignore[attr-defined]
                                     exec_id,
                                     width=cols,


### PR DESCRIPTION
Fixes #74 
This pull request updates default Gemini model settings and improves logging for terminal sessions. The main changes include switching to a newer Gemini model with increased output tokens, updating documentation to reflect this, and replacing print statements with structured logging in the terminal server code.

**Gemini model and configuration updates:**

* Changed the default Gemini model from `models/gemini-1.5-flash` to `models/gemini-flash-latest` and increased the default maximum output tokens from 512 to 2048 in `agent_service.py`.
* Updated `LOCAL_RUNBOOK.md` to mention the new default model and provide guidance for users whose API keys may not have access to it.

**Logging improvements in terminal server:**

* Replaced print statements with `logger.debug` calls for socket close, inbound messages, and terminal resize events in `server.py`, improving log consistency and clarity. [[1]](diffhunk://#diff-38c48b07125f94f3401ed793bdbc1fba118a7d23d852015458a356478a806bf6L343-R343) [[2]](diffhunk://#diff-38c48b07125f94f3401ed793bdbc1fba118a7d23d852015458a356478a806bf6L368-R368) [[3]](diffhunk://#diff-38c48b07125f94f3401ed793bdbc1fba118a7d23d852015458a356478a806bf6L378-R378)