### PR TITLE
Persist lab sessions per user

### DIFF
--- a/backend/tests/test_labs_router.py
+++ b/backend/tests/test_labs_router.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient  # type: ignore[import]
+
+from backend.app.main import app
+from backend.app.services.auth_service import hash_token
+from backend.app.services.storage import Storage, get_storage
+from backend.app.services.runner_client import get_runner_client
+
+
+class StubRunner:
+    def __init__(self) -> None:
+        self.started: list[tuple[str, str]] = []
+        self.stopped: list[str] = []
+
+    async def start(self, session_id: str, lab_slug: str) -> dict[str, str]:
+        self.started.append((session_id, lab_slug))
+        return {"container": f"runner-{session_id}"}
+
+    async def stop(self, session_id: str, preserve_workspace: bool = False) -> dict[str, bool]:
+        self.stopped.append(session_id)
+        return {"stopped": True}
+
+
+def _prepare_storage(tmp_path: Path) -> Storage:
+    storage = Storage(db_path=tmp_path / "labs.db")
+    storage.init()
+    return storage
+
+
+def test_start_lab_replaces_existing_session(tmp_path: Path) -> None:
+    storage = _prepare_storage(tmp_path)
+    runner = StubRunner()
+    app.dependency_overrides[get_storage] = lambda: storage
+    app.dependency_overrides[get_runner_client] = lambda: runner
+
+    token = "replace-token"
+    user = storage.upsert_user_token("replace@example.com", hash_token(token))
+    headers = {"Authorization": f"Bearer {token}"}
+
+    client = TestClient(app)
+
+    first_response = client.post("/labs/lab1/start", headers=headers)
+    assert first_response.status_code == 200
+    first_session_id = first_response.json()["session_id"]
+    assert runner.started[0][0] == first_session_id
+
+    second_response = client.post("/labs/lab1/start", headers=headers)
+    assert second_response.status_code == 200
+    second_payload = second_response.json()
+    assert first_session_id in second_payload["replaced_session_ids"]
+    assert runner.stopped == [first_session_id]
+
+    first_session = storage.get_session(first_session_id)
+    assert first_session is not None
+    assert first_session.get("ended_at") is not None
+
+    active_sessions = storage.get_active_sessions_for_lab(user["user_id"], "lab1")
+    assert len(active_sessions) == 1
+    assert active_sessions[0]["session_id"] == second_payload["session_id"]
+
+    app.dependency_overrides.clear()
+
+
+def test_get_active_session_endpoint(tmp_path: Path) -> None:
+    storage = _prepare_storage(tmp_path)
+    runner = StubRunner()
+    app.dependency_overrides[get_storage] = lambda: storage
+    app.dependency_overrides[get_runner_client] = lambda: runner
+
+    token = "active-token"
+    storage.upsert_user_token("active@example.com", hash_token(token))
+    headers = {"Authorization": f"Bearer {token}"}
+
+    client = TestClient(app)
+
+    empty_response = client.get("/labs/lab1/session", headers=headers)
+    assert empty_response.status_code == 404
+
+    start_response = client.post("/labs/lab1/start", headers=headers)
+    assert start_response.status_code == 200
+    session_id = start_response.json()["session_id"]
+
+    active_response = client.get("/labs/lab1/session", headers=headers)
+    assert active_response.status_code == 200
+    payload = active_response.json()
+    assert payload["session_id"] == session_id
+    assert payload["ttl"] == start_response.json()["ttl"]
+
+    app.dependency_overrides.clear()

--- a/docs/LOCAL_RUNBOOK.md
+++ b/docs/LOCAL_RUNBOOK.md
@@ -102,6 +102,7 @@ The script exits with a non-zero status if any step fails, making it safe to int
 
 - [ ] GitHub login succeeds and the signed-in banner appears.
 - [ ] Starting a lab session creates a new workspace and opens the terminal/editor/inspector panes.
+- [ ] Navigating away (or logging out and back in) restores the same active session instead of creating a fresh one.
 - [ ] File edits autosave and can trigger a build-on-save if enabled.
 - [ ] Agent hints/explanations respond with either Gemini output or the deterministic fallback.
 - [ ] Agent patch suggestions can be applied via the UI and reflected in the editor.

--- a/docs/STATE_SNAPSHOT.md
+++ b/docs/STATE_SNAPSHOT.md
@@ -21,6 +21,7 @@ This local-only note exists so a fresh GPT-5 Codex chat can resume work quickly.
 
 ### Backend (FastAPI)
 - **Sessions:** `/labs/{slug}/start` seeds runner containers; `/sessions/{id}/build|run|stop` control builds and runtime.
+- **Session persistence:** `/labs/{slug}/session` restores the latest active session per user; starting a lab stops any existing session for that lab to keep one workspace alive at a time.
 - **Filesystem:** `/fs/{session}/list|read|write|create|rename|delete` forward to runnerd with workspace sandboxing.
 - **Inspector:** `/sessions/{id}/inspector` surfaces latest attempt metrics, layer list, cache hits, and delta versus the previous attempt.
 - **Terminal:** `/ws/terminal/{session}` upgrades to websocket for interactive shells.

--- a/frontend/src/lib/labs.ts
+++ b/frontend/src/lib/labs.ts
@@ -67,6 +67,19 @@ export async function fetchLab(slug: string): Promise<LabDetail> {
   return apiGet(`/labs/${slug}`);
 }
 
+export type ActiveLabSession = {
+  session_id: string;
+  ttl: number;
+  runner_container: string;
+  created_at: string;
+  expires_at: string;
+  ended_at?: string | null;
+};
+
+export async function fetchActiveLabSession(labSlug: string, token: string): Promise<ActiveLabSession> {
+  return apiGet(`/labs/${labSlug}/session`, { token });
+}
+
 export async function fetchSession(sessionId: string, token: string, limit?: number): Promise<SessionDetail> {
   const params = limit && limit > 0 ? `?limit=${limit}` : "";
   return apiGet(`/sessions/${sessionId}${params}`, { token });


### PR DESCRIPTION
Fixes #80 
This pull request introduces backend and frontend changes to ensure that only one active lab session exists per user and lab, and that users can reliably restore their latest active session when returning to a lab. It also improves session management by automatically ending expired sessions and provides new endpoints and UI feedback for session restoration and replacement. Comprehensive tests are added for the new behaviors.

**Backend session management and API enhancements:**

- Added a new endpoint `/labs/{lab_slug}/session` to fetch the latest active session for a user and lab, supporting session restoration in the frontend.
- Modified the `/labs/{lab_slug}/start` endpoint to automatically stop and mark as ended any existing active sessions for the same user and lab before starting a new one. The response now includes a `replaced_session_ids` field listing any replaced sessions. [[1]](diffhunk://#diff-a870e78cf9bb173290ba31e711741a88b4b91384342c2d089c7457c2877f3a88R78-R106) [[2]](diffhunk://#diff-a870e78cf9bb173290ba31e711741a88b4b91384342c2d089c7457c2877f3a88R21-R38)
- Implemented `get_active_sessions_for_lab` and `get_most_recent_session_for_lab` methods in `Storage` to fetch active (non-expired, non-ended) sessions, and to mark expired sessions as ended automatically.

**Frontend session restoration and feedback:**

- On page load or login, the frontend now attempts to restore the latest active session for the current lab using the new backend endpoint, ensuring users continue with their existing workspace if available. [[1]](diffhunk://#diff-8913cd56f5c33cb5ad1bb8e519f8141ca833f1979c6a08926ec46444ac14ce16R71) [[2]](diffhunk://#diff-8913cd56f5c33cb5ad1bb8e519f8141ca833f1979c6a08926ec46444ac14ce16R81-R131) [[3]](diffhunk://#diff-8913cd56f5c33cb5ad1bb8e519f8141ca833f1979c6a08926ec46444ac14ce16R18-R25) [[4]](diffhunk://#diff-7e045c0774032cb3132eeba961d505df80d342bf3c0c9515ae653fa88541433dR70-R82)
- When starting a new session, the UI now displays which previous session(s) were closed, providing clearer feedback to the user.

**Testing and documentation:**

- Added backend tests for session replacement and restoration logic, verifying that expired sessions are filtered and replaced sessions are properly ended. [[1]](diffhunk://#diff-593d172b79356d3918383c54932756a8dc9d3ff514357accb92a275c623b428aR1-R92) [[2]](diffhunk://#diff-7a3924d6af8b340109d5f78eaa8003843f0912d3c62c182cbf92875cffbb7d2dR126-R164)
- Updated documentation to describe the new session persistence and restoration behavior. [[1]](diffhunk://#diff-73ae907e051a6e6633ef9a1cc591202aca2900b0e926c6b68fa922360e2eb481R105) [[2]](diffhunk://#diff-6cef2d20c1257da4cf0d65e69f34d4150e27aa161bd8492ab3d20e4509ec90edR24)