### PR TITLE
fix: make Lab 1 dockerignore patterns Python-specific

### DIFF
--- a/judge/labs/lab1.py
+++ b/judge/labs/lab1.py
@@ -7,7 +7,7 @@ import httpx  # type: ignore[import]
 
 from judge.models import JudgeResult
 
-REQUIRED_DOCKERIGNORE_PATTERNS = ("node_modules", "venv")
+REQUIRED_DOCKERIGNORE_PATTERNS = ("__pycache__", "venv")
 DEFAULT_PORT = 8080
 HEALTH_PATH = "/health"
 

--- a/labs/lab1/description.md
+++ b/labs/lab1/description.md
@@ -6,7 +6,7 @@ You’re building a tiny web service that says “ok” at `http://localhost:808
 
 1. **`app.py`** – a Python web app (FastAPI is recommended) with a single route `/health` that returns 200 and a simple JSON body (for example `{ "ok": true }`). Make sure the app listens on `0.0.0.0` so it’s reachable from outside the container.
 2. **`requirements.txt`** – list every Python package your app needs (e.g. `fastapi`, `uvicorn`). Docker will install from this file.
-3. **`.dockerignore`** – keep bulky folders (virtual environments, node_modules, cache files, `.git`, etc.) out of the build context so your image builds quickly.
+3. **`.dockerignore`** – keep bulky folders (virtual environments like `venv/`, Python cache files like `__pycache__/`, `.git`, etc.) out of the build context so your image builds quickly.
 4. **`Dockerfile`** – base on a lightweight Python image, copy `requirements.txt`, install dependencies, then copy the rest of the source and start the server on port 8080 when the container runs.
 
 ## Suggested workflow

--- a/labs/lab1/solution.md
+++ b/labs/lab1/solution.md
@@ -46,7 +46,6 @@ uvicorn==0.31.0
 __pycache__/
 *.pyc
 venv/
-node_modules/
 .env
 .git/
 ```


### PR DESCRIPTION
Fixes #94 
Changed required dockerignore patterns from (node_modules, venv) to (__pycache__, venv) to better align with Python focus.

Changes:
- Judge: Updated REQUIRED_DOCKERIGNORE_PATTERNS to Python-specific
- Description: Changed examples from 'node_modules' to '__pycache__/'
- Solution: Removed 'node_modules/' from example .dockerignore

This improves consistency and reduces student confusion since Lab 1 is Python-only and doesn't involve Node.js.